### PR TITLE
feat: establish F2 domain event sequencing

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "db:bootstrap": "node src/scripts/bootstrapCore.js",
     "db:migrate": "node scripts/migrate.js",
     "db:backfill-subscriptions": "node src/scripts/backfillTenantSubscriptions.js",
+    "db:backfill-domain-event-sequences": "node scripts/backfill-domain-event-sequences.js",
     "db:seed-plans": "node src/scripts/seedSubscriptionPlans.js",
     "db:seed-flags": "node src/scripts/seedFeatureFlags.js",
     "edge:sync-kv": "node src/scripts/syncEdgeGatewayKv.js"

--- a/apps/api/scripts/backfill-domain-event-sequences.js
+++ b/apps/api/scripts/backfill-domain-event-sequences.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+const path = require('node:path');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+
+const { database, mongoose } = require('@contexthub/common');
+
+const EVENT_COLLECTION = 'DomainEvents';
+const COUNTER_COLLECTION = 'DomainEventCounters';
+const COUNTER_ID = 'domainEvents';
+const DEFAULT_BATCH_SIZE = 500;
+
+const apply = process.argv.includes('--apply');
+const maintenanceConfirmed = process.argv.includes('--maintenance-confirmed');
+const batchArg = process.argv.find((arg) => arg.startsWith('--batch-size='));
+const requestedBatchSize = batchArg ? Number(batchArg.split('=')[1]) : null;
+const batchSize =
+  Number.isSafeInteger(requestedBatchSize) && requestedBatchSize > 0
+    ? requestedBatchSize
+    : DEFAULT_BATCH_SIZE;
+
+async function getSequenceState(events, counters) {
+  const [missing, sequenced, counter, maximum] = await Promise.all([
+    events.countDocuments({ sequence: { $exists: false } }),
+    events.countDocuments({ sequence: { $type: 'number' } }),
+    counters.findOne({ _id: COUNTER_ID }),
+    events
+      .aggregate([
+        { $match: { sequence: { $type: 'number' } } },
+        { $group: { _id: null, sequence: { $max: '$sequence' } } }
+      ])
+      .next()
+  ]);
+
+  return {
+    missing,
+    sequenced,
+    counterSequence: counter?.sequence || 0,
+    maximumSequence: maximum?.sequence || 0
+  };
+}
+
+async function assertNoDuplicateSequences(events) {
+  const duplicate = await events
+    .aggregate([
+      { $match: { sequence: { $type: 'number' } } },
+      { $group: { _id: '$sequence', count: { $sum: 1 } } },
+      { $match: { count: { $gt: 1 } } },
+      { $limit: 1 }
+    ])
+    .next();
+
+  if (duplicate) {
+    throw new Error(`Duplicate DomainEvent sequence detected: ${duplicate._id}`);
+  }
+}
+
+async function persistCounter(counters, sequence, now) {
+  await counters.updateOne(
+    { _id: COUNTER_ID },
+    {
+      $max: { sequence },
+      $set: { updatedAt: now },
+      $setOnInsert: { createdAt: now }
+    },
+    { upsert: true }
+  );
+}
+
+async function backfill(events, counters, initialSequence) {
+  let sequence = initialSequence;
+  let updated = 0;
+  let operations = [];
+
+  const flush = async () => {
+    if (!operations.length) return;
+
+    const result = await events.bulkWrite(operations, { ordered: true });
+    if (result.modifiedCount !== operations.length) {
+      throw new Error(
+        'DomainEvents changed during backfill. Keep producers stopped and rerun the command.'
+      );
+    }
+
+    await persistCounter(counters, sequence, new Date());
+    updated += result.modifiedCount;
+    console.log('[domain-event-sequence] Progress', { updated, sequence });
+    operations = [];
+  };
+
+  const cursor = events
+    .find(
+      { sequence: { $exists: false } },
+      { projection: { _id: 1, createdAt: 1 } }
+    )
+    .sort({ createdAt: 1, _id: 1 });
+
+  for await (const event of cursor) {
+    sequence += 1;
+    if (!Number.isSafeInteger(sequence)) {
+      throw new Error('DomainEvent sequence exceeded Number.MAX_SAFE_INTEGER');
+    }
+
+    operations.push({
+      updateOne: {
+        filter: { _id: event._id, sequence: { $exists: false } },
+        update: { $set: { sequence } }
+      }
+    });
+
+    if (operations.length >= batchSize) {
+      await flush();
+    }
+  }
+
+  await flush();
+  await persistCounter(counters, sequence, new Date());
+  return { updated, sequence };
+}
+
+async function main() {
+  if (apply && !maintenanceConfirmed) {
+    throw new Error(
+      '--apply requires --maintenance-confirmed because all DomainEvent producers must be stopped'
+    );
+  }
+
+  await database.connectDB();
+  const db = mongoose.connection.db;
+  const events = db.collection(EVENT_COLLECTION);
+  const counters = db.collection(COUNTER_COLLECTION);
+
+  await assertNoDuplicateSequences(events);
+  const before = await getSequenceState(events, counters);
+  console.log('[domain-event-sequence] Current state', before);
+
+  if (!apply) {
+    console.log(
+      '[domain-event-sequence] Dry run only. Stop event producers, then rerun with --apply --maintenance-confirmed.'
+    );
+    return;
+  }
+
+  const initialSequence = Math.max(
+    before.maximumSequence,
+    before.counterSequence
+  );
+  const result = await backfill(events, counters, initialSequence);
+  const after = await getSequenceState(events, counters);
+
+  if (after.missing !== 0 || after.counterSequence < after.maximumSequence) {
+    throw new Error('DomainEvent sequence backfill verification failed');
+  }
+
+  console.log('[domain-event-sequence] Backfill complete', { result, after });
+}
+
+main()
+  .catch((error) => {
+    console.error('[domain-event-sequence] Failed', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    if (mongoose.connection.readyState !== 0) {
+      await database.disconnectDB();
+    }
+  });

--- a/apps/api/src/lib/domainEvents.js
+++ b/apps/api/src/lib/domainEvents.js
@@ -2,6 +2,8 @@ const crypto = require('node:crypto');
 const { DOMAIN_EVENT_TYPES, mongoose } = require('@contexthub/common');
 
 const DOMAIN_EVENT_COLLECTION = 'DomainEvents';
+const DOMAIN_EVENT_COUNTER_COLLECTION = 'DomainEventCounters';
+const DOMAIN_EVENT_COUNTER_ID = 'domainEvents';
 
 function getDb() {
   const connection = mongoose.connection;
@@ -11,10 +13,6 @@ function getDb() {
   return connection.db;
 }
 
-function getCollection(name = DOMAIN_EVENT_COLLECTION) {
-  return getDb().collection(name);
-}
-
 function normalizeTenantId(tenantId) {
   if (!tenantId) {
     return null;
@@ -22,8 +20,37 @@ function normalizeTenantId(tenantId) {
   return typeof tenantId === 'string' ? tenantId : tenantId.toString();
 }
 
-async function emitDomainEvent(tenantId, type, payload = {}, metadata = null) {
+async function allocateDomainEventSequence(db, now = new Date()) {
+  const result = await db.collection(DOMAIN_EVENT_COUNTER_COLLECTION).findOneAndUpdate(
+    { _id: DOMAIN_EVENT_COUNTER_ID },
+    {
+      $inc: { sequence: 1 },
+      $set: { updatedAt: now },
+      $setOnInsert: { createdAt: now }
+    },
+    { upsert: true, returnDocument: 'after' }
+  );
+
+  // MongoDB driver 5 returns a ModifyResult; newer drivers may return the document.
+  const sequence = result?.value?.sequence ?? result?.sequence;
+  if (!Number.isSafeInteger(sequence) || sequence < 1) {
+    throw new Error('[domainEvents] Failed to allocate a valid event sequence');
+  }
+
+  return sequence;
+}
+
+async function recordDomainEvent(
+  tenantId,
+  type,
+  payload = {},
+  metadata = null,
+  dependencies = {}
+) {
+  const randomUUID = dependencies.randomUUID || crypto.randomUUID;
+  const now = dependencies.now ? dependencies.now() : new Date();
   const normalizedTenantId = normalizeTenantId(tenantId);
+
   if (!normalizedTenantId) {
     console.warn('[domainEvents] Missing tenantId. Event not recorded.');
     return null;
@@ -34,12 +61,17 @@ async function emitDomainEvent(tenantId, type, payload = {}, metadata = null) {
     return null;
   }
 
-  const id = crypto.randomUUID();
-  const now = new Date();
+  const db = dependencies.db || getDb();
+
+  // Counter allocation and event insertion are intentionally separate atomic writes.
+  // A failed insert can leave a harmless gap; consumers only require monotonic order.
+  const sequence = await allocateDomainEventSequence(db, now);
+  const id = randomUUID();
 
   const doc = {
     _id: id,
     id,
+    sequence,
     tenantId: normalizedTenantId,
     type,
     occurredAt: now.toISOString(),
@@ -52,13 +84,23 @@ async function emitDomainEvent(tenantId, type, payload = {}, metadata = null) {
     updatedAt: now
   };
 
-  const collection = getCollection();
-  await collection.insertOne(doc);
+  await db.collection(DOMAIN_EVENT_COLLECTION).insertOne(doc);
 
   return id;
 }
 
+async function emitDomainEvent(tenantId, type, payload = {}, metadata = null) {
+  return recordDomainEvent(tenantId, type, payload, metadata);
+}
+
 module.exports = {
   DOMAIN_EVENT_COLLECTION,
-  emitDomainEvent
+  DOMAIN_EVENT_COUNTER_COLLECTION,
+  DOMAIN_EVENT_COUNTER_ID,
+  emitDomainEvent,
+  __testables: {
+    allocateDomainEventSequence,
+    normalizeTenantId,
+    recordDomainEvent
+  }
 };

--- a/apps/api/src/lib/domainEvents.test.js
+++ b/apps/api/src/lib/domainEvents.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { __testables } from './domainEvents'
+
+const { allocateDomainEventSequence, recordDomainEvent } = __testables
+
+function createDb({ counterResult = { value: { sequence: 1 } } } = {}) {
+  const counters = {
+    findOneAndUpdate: vi.fn().mockResolvedValue(counterResult)
+  }
+  const events = {
+    insertOne: vi.fn().mockResolvedValue({ acknowledged: true })
+  }
+  const collection = vi.fn((name) => {
+    if (name === 'DomainEventCounters') return counters
+    if (name === 'DomainEvents') return events
+    throw new Error(`Unexpected collection: ${name}`)
+  })
+
+  return { db: { collection }, counters, events, collection }
+}
+
+describe('domain event sequences', () => {
+  it('allocates the global sequence atomically', async () => {
+    const { db, counters } = createDb({
+      counterResult: { value: { sequence: 42 } }
+    })
+    const now = new Date('2026-08-03T10:00:00.000Z')
+
+    await expect(allocateDomainEventSequence(db, now)).resolves.toBe(42)
+    expect(counters.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: 'domainEvents' },
+      {
+        $inc: { sequence: 1 },
+        $set: { updatedAt: now },
+        $setOnInsert: { createdAt: now }
+      },
+      { upsert: true, returnDocument: 'after' }
+    )
+  })
+
+  it('supports the newer driver document return shape', async () => {
+    const { db } = createDb({ counterResult: { sequence: 7 } })
+
+    await expect(allocateDomainEventSequence(db)).resolves.toBe(7)
+  })
+
+  it('rejects an invalid counter result instead of inserting an unordered event', async () => {
+    const { db } = createDb({ counterResult: { value: null } })
+
+    await expect(allocateDomainEventSequence(db)).rejects.toThrow(
+      'Failed to allocate a valid event sequence'
+    )
+  })
+
+  it('writes the allocated sequence into the event before returning its id', async () => {
+    const { db, events } = createDb({
+      counterResult: { value: { sequence: 11 } }
+    })
+    const now = new Date('2026-08-03T12:30:00.000Z')
+
+    const eventId = await recordDomainEvent(
+      'tenant-a',
+      'content.published',
+      { contentId: 'content-1' },
+      { source: 'test' },
+      {
+        db,
+        randomUUID: () => 'event-1',
+        now: () => now
+      }
+    )
+
+    expect(eventId).toBe('event-1')
+    expect(events.insertOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _id: 'event-1',
+        id: 'event-1',
+        sequence: 11,
+        tenantId: 'tenant-a',
+        type: 'content.published',
+        occurredAt: now.toISOString()
+      })
+    )
+  })
+
+  it('does not allocate a sequence for invalid events', async () => {
+    const { db, counters, events } = createDb()
+
+    await expect(
+      recordDomainEvent(null, 'content.published', {}, null, { db })
+    ).resolves.toBeNull()
+    await expect(
+      recordDomainEvent('tenant-a', 'unknown.event', {}, null, { db })
+    ).resolves.toBeNull()
+
+    expect(counters.findOneAndUpdate).not.toHaveBeenCalled()
+    expect(events.insertOne).not.toHaveBeenCalled()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "create:index": "node scripts/create-indexes.mjs",
     "db:seed": "turbo dev --filter=@contexthub/api -- --seed",
     "db:migrate": "turbo dev --filter=@contexthub/api -- --migrate",
+    "db:backfill-domain-event-sequences": "node apps/api/scripts/backfill-domain-event-sequences.js",
     "dispatch:webhooks": "node apps/api/scripts/dispatch-webhooks.js",
     "cron:webhooks": "node apps/api/scripts/webhook-cron.js"
   },

--- a/packages/common/src/domainEvents.js
+++ b/packages/common/src/domainEvents.js
@@ -50,6 +50,7 @@ const DOMAIN_EVENT_TYPES = Object.freeze([
  * Canonical domain event contract shared across services.
  * @typedef {Object} DomainEvent
  * @property {string} id - Unique identifier (UUID v4 preferred)
+ * @property {number} sequence - Global monotonically increasing delivery sequence
  * @property {string} tenantId - Tenant slug/id to enforce isolation
  * @property {DomainEventType} type - Event type name
  * @property {string} occurredAt - ISO string representing when the event finished

--- a/packages/common/src/models/DomainEvent.js
+++ b/packages/common/src/models/DomainEvent.js
@@ -7,6 +7,8 @@ const domainEventSchema = new Schema(
   {
     _id: { type: String, required: true },
     id: { type: String, required: true },
+    // Optional during the controlled F2 backfill; all newly emitted events have it.
+    sequence: { type: Number, min: 1 },
     tenantId: { type: String, required: true },
     type: { type: String, required: true },
     occurredAt: { type: String, required: true },
@@ -30,6 +32,17 @@ const domainEventSchema = new Schema(
 );
 
 domainEventSchema.index({ status: 1, createdAt: 1 });
+domainEventSchema.index(
+  { sequence: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { sequence: { $type: 'number' } }
+  }
+);
+domainEventSchema.index(
+  { tenantId: 1, sequence: 1 },
+  { partialFilterExpression: { sequence: { $type: 'number' } } }
+);
 domainEventSchema.index(
   { createdAt: 1 },
   { expireAfterSeconds: DOMAIN_EVENT_RETENTION_SECONDS }

--- a/packages/common/src/models/DomainEventCounter.js
+++ b/packages/common/src/models/DomainEventCounter.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const domainEventCounterSchema = new Schema(
+  {
+    _id: { type: String, required: true },
+    sequence: { type: Number, required: true, min: 0, default: 0 },
+    createdAt: { type: Date, default: Date.now },
+    updatedAt: { type: Date, default: Date.now }
+  },
+  {
+    collection: 'DomainEventCounters',
+    skipTenantEnforcement: true,
+    versionKey: false
+  }
+);
+
+const DomainEventCounter = mongoose.model(
+  'DomainEventCounter',
+  domainEventCounterSchema
+);
+
+module.exports = DomainEventCounter;

--- a/packages/common/src/models/DomainEventCursor.js
+++ b/packages/common/src/models/DomainEventCursor.js
@@ -1,0 +1,43 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const domainEventCursorSchema = new Schema(
+  {
+    consumer: { type: String, required: true, trim: true },
+    partition: { type: String, required: true, trim: true },
+    active: { type: Boolean, default: true },
+    initialPosition: {
+      type: String,
+      enum: ['earliest', 'latest', 'backfill'],
+      required: true
+    },
+    lastSequence: { type: Number, min: 0, default: 0 },
+    highWatermark: { type: Number, min: 0, default: null },
+    leaseOwner: { type: String, default: null },
+    leaseUntil: { type: Date, default: null },
+    failureSequence: { type: Number, min: 1, default: null },
+    attempt: { type: Number, min: 0, default: 0 },
+    nextAttemptAt: { type: Date, default: null },
+    lastError: { type: Schema.Types.Mixed, default: null }
+  },
+  {
+    collection: 'DomainEventCursors',
+    skipTenantEnforcement: true,
+    timestamps: true,
+    versionKey: false
+  }
+);
+
+domainEventCursorSchema.index(
+  { consumer: 1, partition: 1 },
+  { unique: true }
+);
+domainEventCursorSchema.index({ active: 1, nextAttemptAt: 1, leaseUntil: 1 });
+
+const DomainEventCursor = mongoose.model(
+  'DomainEventCursor',
+  domainEventCursorSchema
+);
+
+module.exports = DomainEventCursor;

--- a/packages/common/src/models/DomainEventDeadLetter.js
+++ b/packages/common/src/models/DomainEventDeadLetter.js
@@ -1,0 +1,39 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const domainEventDeadLetterSchema = new Schema(
+  {
+    consumer: { type: String, required: true, trim: true },
+    partition: { type: String, required: true, trim: true },
+    eventId: { type: String, required: true },
+    eventSequence: { type: Number, required: true, min: 1 },
+    tenantId: { type: String, required: true },
+    eventType: { type: String, required: true },
+    event: { type: Schema.Types.Mixed, required: true },
+    attempts: { type: Number, required: true, min: 1 },
+    error: { type: Schema.Types.Mixed, required: true },
+    failedAt: { type: Date, required: true, default: Date.now },
+    resolvedAt: { type: Date, default: null },
+    resolution: { type: Schema.Types.Mixed, default: null }
+  },
+  {
+    collection: 'DomainEventDeadLetters',
+    skipTenantEnforcement: true,
+    timestamps: true,
+    versionKey: false
+  }
+);
+
+domainEventDeadLetterSchema.index(
+  { consumer: 1, partition: 1, eventSequence: 1 },
+  { unique: true }
+);
+domainEventDeadLetterSchema.index({ resolvedAt: 1, failedAt: 1 });
+
+const DomainEventDeadLetter = mongoose.model(
+  'DomainEventDeadLetter',
+  domainEventDeadLetterSchema
+);
+
+module.exports = DomainEventDeadLetter;

--- a/packages/common/src/models/domainEventDeliveryModels.test.mjs
+++ b/packages/common/src/models/domainEventDeliveryModels.test.mjs
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import models from './index.js';
+
+const findIndex = (model, fields) =>
+  model.schema
+    .indexes()
+    .find(([candidate]) => JSON.stringify(candidate) === JSON.stringify(fields));
+
+describe('domain event delivery models', () => {
+  it('defines monotonic sequence indexes without requiring legacy rows to have a sequence', () => {
+    const globalSequence = findIndex(models.DomainEvent, { sequence: 1 });
+    const tenantSequence = findIndex(models.DomainEvent, {
+      tenantId: 1,
+      sequence: 1
+    });
+
+    expect(globalSequence?.[1]).toMatchObject({
+      unique: true,
+      partialFilterExpression: { sequence: { $type: 'number' } }
+    });
+    expect(tenantSequence?.[1]).toMatchObject({
+      partialFilterExpression: { sequence: { $type: 'number' } }
+    });
+    expect(models.DomainEvent.schema.path('sequence').isRequired).toBeFalsy();
+  });
+
+  it('keeps one cursor per consumer partition', () => {
+    expect(models.DomainEventCursor.collection.collectionName).toBe(
+      'DomainEventCursors'
+    );
+    expect(
+      findIndex(models.DomainEventCursor, { consumer: 1, partition: 1 })?.[1]
+    ).toMatchObject({ unique: true });
+  });
+
+  it('deduplicates dead letters by consumer partition and event sequence', () => {
+    expect(models.DomainEventDeadLetter.collection.collectionName).toBe(
+      'DomainEventDeadLetters'
+    );
+    expect(
+      findIndex(models.DomainEventDeadLetter, {
+        consumer: 1,
+        partition: 1,
+        eventSequence: 1
+      })?.[1]
+    ).toMatchObject({ unique: true });
+  });
+});

--- a/packages/common/src/models/index.js
+++ b/packages/common/src/models/index.js
@@ -44,6 +44,9 @@ const WebhookOutbox = require('./WebhookOutbox');
 const RevokedToken = require('./RevokedToken');
 const ActivityLog = require('./ActivityLog');
 const DomainEvent = require('./DomainEvent');
+const DomainEventCounter = require('./DomainEventCounter');
+const DomainEventCursor = require('./DomainEventCursor');
+const DomainEventDeadLetter = require('./DomainEventDeadLetter');
 
 module.exports = {
   Tenant,
@@ -85,5 +88,8 @@ module.exports = {
   RevokedToken,
   ActivityLog,
   DomainEvent,
+  DomainEventCounter,
+  DomainEventCursor,
+  DomainEventDeadLetter,
   mongoose
 };


### PR DESCRIPTION
## What changed

- allocate a global monotonic sequence for every newly emitted domain event
- add partial global and tenant/sequence indexes compatible with legacy rows
- add persistent cursor, counter, and consumer dead-letter models
- add a dry-run-by-default, maintenance-gated sequence backfill command
- add unit and schema contract tests

## Why

F2 consumers need an ordering key that is independent from webhook delivery state and
supports tenant-partitioned at-least-once cursors. Existing random event UUIDs cannot be
used for ordered cursor progression.

## Rollout impact

The existing webhook flow remains unchanged. Sequence allocation adds one atomic MongoDB
counter write before each DomainEvent insert. Legacy events remain readable because the
field is optional until the controlled backfill is run. The backfill refuses write mode
unless `--maintenance-confirmed` is supplied.

## Validation

- `corepack pnpm version:check`
- `corepack pnpm lint`
- `corepack pnpm test` (87 tests passed)
- migration write guard verified with `--apply` without maintenance confirmation
