### PR TITLE
feat: add F2 consumer registry and runner

### DIFF
--- a/apps/api/src/lib/domainEventConsumerRegistry.js
+++ b/apps/api/src/lib/domainEventConsumerRegistry.js
@@ -1,0 +1,171 @@
+const { DOMAIN_EVENT_TYPES } = require('@contexthub/common');
+
+const CONSUMER_NAME_PATTERN = /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/;
+const INITIAL_POSITIONS = Object.freeze(['earliest', 'latest', 'backfill']);
+const DEFAULT_RETRY_POLICY = Object.freeze({
+  baseDelayMs: 1000,
+  maxDelayMs: 5 * 60 * 1000,
+  multiplier: 2
+});
+const MAX_BATCH_SIZE = 500;
+const MAX_ATTEMPTS = 100;
+
+class DomainEventConsumerRegistryError extends Error {
+  constructor(message, code = 'DOMAIN_EVENT_CONSUMER_INVALID') {
+    super(message);
+    this.name = 'DomainEventConsumerRegistryError';
+    this.code = code;
+  }
+}
+
+function invalid(message) {
+  throw new DomainEventConsumerRegistryError(message);
+}
+
+function requireInteger(value, label, minimum, maximum) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    invalid(`${label} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return value;
+}
+
+function normalizeName(name) {
+  const normalized = typeof name === 'string' ? name.trim() : '';
+  if (!normalized || normalized.length > 80 || !CONSUMER_NAME_PATTERN.test(normalized)) {
+    invalid(
+      'consumer name must be 1-80 lowercase characters using letters, numbers, dots or hyphens'
+    );
+  }
+  return normalized;
+}
+
+function normalizeTypes(types) {
+  if (!Array.isArray(types) || types.length === 0) {
+    invalid('consumer types must be a non-empty array');
+  }
+
+  const normalized = types.map((type) =>
+    typeof type === 'string' ? type.trim() : ''
+  );
+  if (normalized.some((type) => !DOMAIN_EVENT_TYPES.includes(type))) {
+    const unknown = normalized.find((type) => !DOMAIN_EVENT_TYPES.includes(type));
+    invalid(`consumer event type is not supported: ${unknown || '<empty>'}`);
+  }
+  if (new Set(normalized).size !== normalized.length) {
+    invalid('consumer event types must not contain duplicates');
+  }
+
+  return Object.freeze(normalized);
+}
+
+function normalizeRetry(retry) {
+  if (retry === undefined) {
+    return DEFAULT_RETRY_POLICY;
+  }
+  if (!retry || typeof retry !== 'object' || Array.isArray(retry)) {
+    invalid('consumer retry must be an object');
+  }
+
+  const baseDelayMs = requireInteger(
+    retry.baseDelayMs,
+    'consumer retry.baseDelayMs',
+    0,
+    24 * 60 * 60 * 1000
+  );
+  const maxDelayMs = requireInteger(
+    retry.maxDelayMs,
+    'consumer retry.maxDelayMs',
+    baseDelayMs,
+    7 * 24 * 60 * 60 * 1000
+  );
+  const multiplier = retry.multiplier;
+  if (!Number.isFinite(multiplier) || multiplier < 1 || multiplier > 10) {
+    invalid('consumer retry.multiplier must be between 1 and 10');
+  }
+
+  return Object.freeze({ baseDelayMs, maxDelayMs, multiplier });
+}
+
+function normalizeRegistration(name, config) {
+  const normalizedName = normalizeName(name);
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    invalid(`consumer config must be an object: ${normalizedName}`);
+  }
+  if (config.name !== undefined && normalizeName(config.name) !== normalizedName) {
+    invalid(`consumer config name does not match registration name: ${normalizedName}`);
+  }
+  if (!INITIAL_POSITIONS.includes(config.initialPosition)) {
+    invalid(
+      `consumer initialPosition must be one of: ${INITIAL_POSITIONS.join(', ')}`
+    );
+  }
+  if (typeof config.handle !== 'function') {
+    invalid(`consumer handle must be a function: ${normalizedName}`);
+  }
+
+  return Object.freeze({
+    name: normalizedName,
+    types: normalizeTypes(config.types),
+    batchSize: requireInteger(
+      config.batchSize,
+      'consumer batchSize',
+      1,
+      MAX_BATCH_SIZE
+    ),
+    maxAttempts: requireInteger(
+      config.maxAttempts,
+      'consumer maxAttempts',
+      1,
+      MAX_ATTEMPTS
+    ),
+    retry: normalizeRetry(config.retry),
+    initialPosition: config.initialPosition,
+    handle: config.handle
+  });
+}
+
+function createDomainEventConsumerRegistry() {
+  const registrations = new Map();
+
+  return Object.freeze({
+    register(name, config) {
+      const registration = normalizeRegistration(name, config);
+      if (registrations.has(registration.name)) {
+        throw new DomainEventConsumerRegistryError(
+          `domain event consumer is already registered: ${registration.name}`,
+          'DOMAIN_EVENT_CONSUMER_COLLISION'
+        );
+      }
+      registrations.set(registration.name, registration);
+      return registration;
+    },
+
+    get(name) {
+      return registrations.get(normalizeName(name)) || null;
+    },
+
+    has(name) {
+      return registrations.has(normalizeName(name));
+    },
+
+    list() {
+      return Object.freeze(Array.from(registrations.values()));
+    }
+  });
+}
+
+const domainEventConsumerRegistry = createDomainEventConsumerRegistry();
+
+module.exports = {
+  DEFAULT_RETRY_POLICY,
+  INITIAL_POSITIONS,
+  DomainEventConsumerRegistryError,
+  createDomainEventConsumerRegistry,
+  domainEventConsumerRegistry,
+  __testables: {
+    normalizeName,
+    normalizeRegistration,
+    normalizeRetry,
+    normalizeTypes
+  }
+};

--- a/apps/api/src/lib/domainEventConsumerRegistry.test.js
+++ b/apps/api/src/lib/domainEventConsumerRegistry.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  DomainEventConsumerRegistryError,
+  createDomainEventConsumerRegistry
+} from './domainEventConsumerRegistry'
+
+function validConfig(overrides = {}) {
+  return {
+    types: ['content.published', 'content.updated'],
+    batchSize: 100,
+    maxAttempts: 8,
+    retry: {
+      baseDelayMs: 1000,
+      maxDelayMs: 60000,
+      multiplier: 2
+    },
+    initialPosition: 'backfill',
+    handle: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('domain event consumer registry', () => {
+  it('registers and freezes a validated consumer contract', () => {
+    const registry = createDomainEventConsumerRegistry()
+    const registration = registry.register(
+      'semantic-search-indexer',
+      validConfig()
+    )
+
+    expect(registry.get('semantic-search-indexer')).toBe(registration)
+    expect(registry.list()).toEqual([registration])
+    expect(Object.isFrozen(registration)).toBe(true)
+    expect(Object.isFrozen(registration.types)).toBe(true)
+    expect(Object.isFrozen(registration.retry)).toBe(true)
+  })
+
+  it('fails fast on name collisions', () => {
+    const registry = createDomainEventConsumerRegistry()
+    registry.register('semantic-search-indexer', validConfig())
+
+    expect(() =>
+      registry.register('semantic-search-indexer', validConfig())
+    ).toThrowError(
+      expect.objectContaining({
+        name: 'DomainEventConsumerRegistryError',
+        code: 'DOMAIN_EVENT_CONSUMER_COLLISION'
+      })
+    )
+  })
+
+  it.each([
+    ['invalid name', 'Semantic Search', validConfig()],
+    [
+      'unknown event type',
+      'semantic-search',
+      validConfig({ types: ['content.unknown'] })
+    ],
+    [
+      'duplicate event type',
+      'semantic-search',
+      validConfig({ types: ['content.updated', 'content.updated'] })
+    ],
+    ['empty event types', 'semantic-search', validConfig({ types: [] })],
+    ['zero batch size', 'semantic-search', validConfig({ batchSize: 0 })],
+    ['zero attempts', 'semantic-search', validConfig({ maxAttempts: 0 })],
+    [
+      'invalid initial position',
+      'semantic-search',
+      validConfig({ initialPosition: 'silent-latest' })
+    ],
+    [
+      'invalid retry range',
+      'semantic-search',
+      validConfig({
+        retry: { baseDelayMs: 10000, maxDelayMs: 1000, multiplier: 2 }
+      })
+    ],
+    ['missing handler', 'semantic-search', validConfig({ handle: null })]
+  ])('rejects %s', (_label, name, config) => {
+    const registry = createDomainEventConsumerRegistry()
+
+    expect(() => registry.register(name, config)).toThrow(
+      DomainEventConsumerRegistryError
+    )
+  })
+
+  it('accepts the explicit earliest and latest start policies', () => {
+    const registry = createDomainEventConsumerRegistry()
+
+    expect(
+      registry.register('earliest-consumer',
+        validConfig({ initialPosition: 'earliest' })
+      ).initialPosition
+    ).toBe('earliest')
+    expect(
+      registry.register('latest-consumer',
+        validConfig({ initialPosition: 'latest' })
+      ).initialPosition
+    ).toBe('latest')
+  })
+})

--- a/apps/api/src/lib/domainEventConsumerRunner.js
+++ b/apps/api/src/lib/domainEventConsumerRunner.js
@@ -1,0 +1,275 @@
+const crypto = require('node:crypto');
+const {
+  domainEventConsumerRegistry
+} = require('./domainEventConsumerRegistry');
+const {
+  DomainEventConsumerLeaseLostError,
+  createDomainEventConsumerStore
+} = require('./domainEventConsumerStore');
+
+class DomainEventConsumerRunnerError extends Error {
+  constructor(message, code = 'DOMAIN_EVENT_CONSUMER_RUNNER_ERROR') {
+    super(message);
+    this.name = 'DomainEventConsumerRunnerError';
+    this.code = code;
+  }
+}
+
+function serializeError(error) {
+  const message = String(error?.message || error || 'Domain event consumer failed');
+  return {
+    name: String(error?.name || 'Error').slice(0, 200),
+    message: message.slice(0, 4000),
+    code: error?.code ? String(error.code).slice(0, 200) : null,
+    retryable:
+      typeof error?.retryable === 'boolean' ? error.retryable : null
+  };
+}
+
+function calculateRetryDelay(retry, attempt) {
+  const exponent = Math.max(0, attempt - 1);
+  const candidate = retry.baseDelayMs * retry.multiplier ** exponent;
+  return Math.min(retry.maxDelayMs, Math.round(candidate));
+}
+
+function createDomainEventConsumerRunner(options = {}) {
+  const registry = options.registry || domainEventConsumerRegistry;
+  const store = options.store || createDomainEventConsumerStore(options.storeOptions);
+  const clock = options.clock || (() => new Date());
+  const ownerId = String(options.ownerId || crypto.randomUUID()).trim();
+  const logger = options.logger || console;
+
+  if (!ownerId) {
+    throw new DomainEventConsumerRunnerError(
+      'runner ownerId is required',
+      'DOMAIN_EVENT_CONSUMER_OWNER_REQUIRED'
+    );
+  }
+
+  const now = () => {
+    const value = clock();
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      throw new DomainEventConsumerRunnerError('clock returned an invalid date');
+    }
+    return date;
+  };
+
+  async function runPartition(consumerName, tenantId) {
+    const registration = registry.get(consumerName);
+    if (!registration) {
+      throw new DomainEventConsumerRunnerError(
+        `domain event consumer is not registered: ${consumerName}`,
+        'DOMAIN_EVENT_CONSUMER_NOT_REGISTERED'
+      );
+    }
+
+    let cursor = await store.initializeCursor(registration, tenantId);
+    if (!cursor.active) {
+      return { status: 'inactive', consumer: registration.name, tenantId };
+    }
+    if (cursor.backfillStatus === 'pending') {
+      return {
+        status: 'backfill-required',
+        consumer: registration.name,
+        tenantId,
+        highWatermark: cursor.highWatermark
+      };
+    }
+
+    const leasedCursor = await store.acquireLease(
+      registration,
+      tenantId,
+      ownerId
+    );
+    if (!leasedCursor) {
+      cursor = await store.getCursor(registration.name, tenantId);
+      if (cursor?.nextAttemptAt && new Date(cursor.nextAttemptAt) > now()) {
+        return {
+          status: 'backoff',
+          consumer: registration.name,
+          tenantId,
+          nextAttemptAt: cursor.nextAttemptAt
+        };
+      }
+      return { status: 'busy', consumer: registration.name, tenantId };
+    }
+
+    const expectedLastSequence = leasedCursor.lastSequence;
+    const events = await store.readEvents(
+      registration,
+      tenantId,
+      expectedLastSequence
+    );
+
+    if (events.length === 0) {
+      const released = await store.releaseLease(leasedCursor, ownerId);
+      if (!released) {
+        throw new DomainEventConsumerLeaseLostError(
+          'consumer lease was lost before idle release'
+        );
+      }
+      return {
+        status: 'idle',
+        consumer: registration.name,
+        tenantId,
+        lastSequence: expectedLastSequence
+      };
+    }
+
+    const deadLetterSequences = await store.readDeadLetterSequences(
+      registration,
+      leasedCursor,
+      events.map((event) => event.sequence)
+    );
+    let handled = 0;
+    for (const event of events) {
+      if (deadLetterSequences.has(event.sequence)) {
+        await store.advanceCursor(
+          leasedCursor,
+          ownerId,
+          expectedLastSequence,
+          event.sequence
+        );
+        return {
+          status: 'dead-letter-recovered',
+          consumer: registration.name,
+          tenantId,
+          eventId: event.id,
+          eventSequence: event.sequence,
+          handledBeforeRecovery: handled
+        };
+      }
+
+      await store.renewLease(leasedCursor, ownerId, expectedLastSequence);
+      const attempt =
+        leasedCursor.failureSequence === event.sequence
+          ? leasedCursor.attempt + 1
+          : 1;
+
+      try {
+        // One-element arrays isolate poison events while preserving the public
+        // batch-shaped handler contract and at-least-once replay semantics.
+        await registration.handle([event],
+          Object.freeze({
+            consumer: registration.name,
+            partition: leasedCursor.partition,
+            tenantId,
+            attempt,
+            ownerId
+          })
+        );
+        handled += 1;
+      } catch (error) {
+        const normalizedError = serializeError(error);
+        if (attempt < registration.maxAttempts) {
+          const delayMs = calculateRetryDelay(registration.retry, attempt);
+          const nextAttemptAt = new Date(now().getTime() + delayMs);
+          await store.scheduleRetry({
+            cursor: leasedCursor,
+            ownerId,
+            expectedLastSequence,
+            eventSequence: event.sequence,
+            attempt,
+            nextAttemptAt,
+            error: normalizedError
+          });
+          return {
+            status: 'retry-scheduled',
+            consumer: registration.name,
+            tenantId,
+            eventId: event.id,
+            eventSequence: event.sequence,
+            attempt,
+            nextAttemptAt,
+            handledBeforeFailure: handled
+          };
+        }
+
+        // DLQ is persisted first. If cursor advancement crashes, the unique DLQ
+        // key makes the replay idempotent and the event cannot be silently lost.
+        await store.persistDeadLetter({
+          registration,
+          cursor: leasedCursor,
+          tenantId,
+          event,
+          attempt,
+          error: normalizedError
+        });
+        await store.advanceCursor(
+          leasedCursor,
+          ownerId,
+          expectedLastSequence,
+          event.sequence
+        );
+        return {
+          status: 'dead-lettered',
+          consumer: registration.name,
+          tenantId,
+          eventId: event.id,
+          eventSequence: event.sequence,
+          attempt,
+          handledBeforeFailure: handled
+        };
+      }
+    }
+
+    const lastEvent = events.at(-1);
+    await store.advanceCursor(
+      leasedCursor,
+      ownerId,
+      expectedLastSequence,
+      lastEvent.sequence
+    );
+    return {
+      status: 'processed',
+      consumer: registration.name,
+      tenantId,
+      processed: handled,
+      fromSequence: expectedLastSequence,
+      toSequence: lastEvent.sequence
+    };
+  }
+
+  async function runTenant(tenantId) {
+    const results = [];
+    for (const registration of registry.list()) {
+      try {
+        results.push(await runPartition(registration.name, tenantId));
+      } catch (error) {
+        logger.error('[domainEventConsumerRunner] Consumer failed', {
+          consumer: registration.name,
+          tenantId,
+          error: serializeError(error)
+        });
+        results.push({
+          status: 'failed',
+          consumer: registration.name,
+          tenantId,
+          error: serializeError(error)
+        });
+      }
+    }
+    return results;
+  }
+
+  async function completeBackfill(consumerName, tenantId, highWatermark) {
+    const registration = registry.get(consumerName);
+    if (!registration) {
+      throw new DomainEventConsumerRunnerError(
+        `domain event consumer is not registered: ${consumerName}`,
+        'DOMAIN_EVENT_CONSUMER_NOT_REGISTERED'
+      );
+    }
+    await store.completeBackfill(registration, tenantId, highWatermark);
+  }
+
+  return Object.freeze({ completeBackfill, ownerId, runPartition, runTenant });
+}
+
+module.exports = {
+  DomainEventConsumerRunnerError,
+  calculateRetryDelay,
+  createDomainEventConsumerRunner,
+  serializeError
+};

--- a/apps/api/src/lib/domainEventConsumerRunner.test.js
+++ b/apps/api/src/lib/domainEventConsumerRunner.test.js
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createDomainEventConsumerRegistry } from './domainEventConsumerRegistry'
+import {
+  calculateRetryDelay,
+  createDomainEventConsumerRunner
+} from './domainEventConsumerRunner'
+
+const NOW = new Date('2026-08-03T15:00:00.000Z')
+
+function event(sequence) {
+  return {
+    _id: `event-${sequence}`,
+    id: `event-${sequence}`,
+    sequence,
+    tenantId: 'tenant-a',
+    type: 'content.updated',
+    occurredAt: NOW.toISOString(),
+    payload: {}
+  }
+}
+
+function setup({
+  handle = vi.fn().mockResolvedValue(undefined),
+  maxAttempts = 3,
+  cursor = {}
+} = {}) {
+  const registry = createDomainEventConsumerRegistry()
+  registry.register('test-consumer', {
+    types: ['content.updated'],
+    batchSize: 10,
+    maxAttempts,
+    retry: { baseDelayMs: 1000, maxDelayMs: 10000, multiplier: 2 },
+    initialPosition: 'earliest',
+    handle
+  })
+  const storedCursor = {
+    _id: 'cursor-1',
+    consumer: 'test-consumer',
+    partition: 'tenant:tenant-a',
+    active: true,
+    initialPosition: 'earliest',
+    lastSequence: 0,
+    failureSequence: null,
+    attempt: 0,
+    nextAttemptAt: null,
+    backfillStatus: null,
+    ...cursor
+  }
+  const store = {
+    initializeCursor: vi.fn().mockResolvedValue(storedCursor),
+    acquireLease: vi.fn().mockResolvedValue(storedCursor),
+    getCursor: vi.fn().mockResolvedValue(storedCursor),
+    readEvents: vi.fn().mockResolvedValue([]),
+    readDeadLetterSequences: vi.fn().mockResolvedValue(new Set()),
+    renewLease: vi.fn().mockResolvedValue(new Date(NOW.getTime() + 30000)),
+    releaseLease: vi.fn().mockResolvedValue(true),
+    scheduleRetry: vi.fn().mockResolvedValue(undefined),
+    persistDeadLetter: vi.fn().mockResolvedValue(undefined),
+    advanceCursor: vi.fn().mockResolvedValue(undefined),
+    completeBackfill: vi.fn().mockResolvedValue(undefined)
+  }
+  const logger = { error: vi.fn() }
+  const runner = createDomainEventConsumerRunner({
+    registry,
+    store,
+    ownerId: 'runner-1',
+    clock: () => NOW,
+    logger
+  })
+  return { handle, logger, registry, runner, store, storedCursor }
+}
+
+describe('domain event consumer runner', () => {
+  it('delivers tenant events in sequence and advances only after all succeed', async () => {
+    const context = setup()
+    context.store.readEvents.mockResolvedValue([event(2), event(5)])
+
+    await expect(
+      context.runner.runPartition('test-consumer', 'tenant-a')
+    ).resolves.toMatchObject({
+      status: 'processed',
+      processed: 2,
+      fromSequence: 0,
+      toSequence: 5
+    })
+    expect(context.handle).toHaveBeenNthCalledWith(
+      1,
+      [expect.objectContaining({ sequence: 2 })],
+      expect.objectContaining({ partition: 'tenant:tenant-a', attempt: 1 })
+    )
+    expect(context.handle).toHaveBeenNthCalledWith(
+      2,
+      [expect.objectContaining({ sequence: 5 })],
+      expect.any(Object)
+    )
+    expect(context.store.advanceCursor).toHaveBeenCalledOnce()
+    expect(context.store.advanceCursor).toHaveBeenCalledWith(
+      context.storedCursor,
+      'runner-1',
+      0,
+      5
+    )
+  })
+
+  it('schedules exponential retry without moving the cursor', async () => {
+    const handle = vi.fn().mockRejectedValue(new Error('temporary'))
+    const context = setup({ handle })
+    context.store.readEvents.mockResolvedValue([event(1), event(2)])
+
+    await expect(
+      context.runner.runPartition('test-consumer', 'tenant-a')
+    ).resolves.toMatchObject({
+      status: 'retry-scheduled',
+      eventSequence: 1,
+      attempt: 1,
+      nextAttemptAt: new Date('2026-08-03T15:00:01.000Z')
+    })
+    expect(context.store.scheduleRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedLastSequence: 0,
+        eventSequence: 1,
+        attempt: 1,
+        nextAttemptAt: new Date('2026-08-03T15:00:01.000Z')
+      })
+    )
+    expect(context.store.advanceCursor).not.toHaveBeenCalled()
+    expect(handle).toHaveBeenCalledOnce()
+  })
+
+  it('persists DLQ before advancing past a poison event at max attempts', async () => {
+    const handle = vi.fn().mockRejectedValue(new Error('poison'))
+    const context = setup({
+      handle,
+      maxAttempts: 3,
+      cursor: { failureSequence: 7, attempt: 2 }
+    })
+    context.store.readEvents.mockResolvedValue([event(7), event(8)])
+
+    await expect(
+      context.runner.runPartition('test-consumer', 'tenant-a')
+    ).resolves.toMatchObject({
+      status: 'dead-lettered',
+      eventSequence: 7,
+      attempt: 3
+    })
+    expect(context.store.persistDeadLetter).toHaveBeenCalledOnce()
+    expect(context.store.advanceCursor).toHaveBeenCalledWith(
+      context.storedCursor,
+      'runner-1',
+      0,
+      7
+    )
+    expect(
+      context.store.persistDeadLetter.mock.invocationCallOrder[0]
+    ).toBeLessThan(context.store.advanceCursor.mock.invocationCallOrder[0])
+    expect(handle).toHaveBeenCalledOnce()
+  })
+
+  it('recovers a DLQ-first crash without invoking the handler again', async () => {
+    const context = setup()
+    context.store.readEvents.mockResolvedValue([event(4)])
+    context.store.readDeadLetterSequences.mockResolvedValue(new Set([4]))
+
+    await expect(
+      context.runner.runPartition('test-consumer', 'tenant-a')
+    ).resolves.toMatchObject({
+      status: 'dead-letter-recovered',
+      eventSequence: 4
+    })
+    expect(context.handle).not.toHaveBeenCalled()
+    expect(context.store.advanceCursor).toHaveBeenCalledWith(
+      context.storedCursor,
+      'runner-1',
+      0,
+      4
+    )
+  })
+
+  it('replays when handling succeeded but cursor advancement crashed', async () => {
+    const context = setup()
+    context.store.readEvents.mockResolvedValue([event(1)])
+    context.store.advanceCursor
+      .mockRejectedValueOnce(new Error('crash before cursor'))
+      .mockResolvedValueOnce(undefined)
+
+    await expect(
+      context.runner.runPartition('test-consumer', 'tenant-a')
+    ).rejects.toThrow('crash before cursor')
+    await expect(
+      context.runner.runPartition('test-consumer', 'tenant-a')
+    ).resolves.toMatchObject({ status: 'processed', toSequence: 1 })
+    expect(context.handle).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not acquire a backfill cursor until snapshot completion', async () => {
+    const context = setup({
+      cursor: { backfillStatus: 'pending', highWatermark: 33 }
+    })
+
+    await expect(
+      context.runner.runPartition('test-consumer', 'tenant-a')
+    ).resolves.toMatchObject({
+      status: 'backfill-required',
+      highWatermark: 33
+    })
+    expect(context.store.acquireLease).not.toHaveBeenCalled()
+  })
+
+  it('returns busy when another runner owns the tenant partition lease', async () => {
+    const context = setup()
+    context.store.acquireLease.mockResolvedValue(null)
+    context.store.getCursor.mockResolvedValue({
+      ...context.storedCursor,
+      leaseOwner: 'runner-2',
+      leaseUntil: new Date('2026-08-03T15:01:00.000Z')
+    })
+
+    await expect(
+      context.runner.runPartition('test-consumer', 'tenant-a')
+    ).resolves.toMatchObject({ status: 'busy', consumer: 'test-consumer' })
+    expect(context.handle).not.toHaveBeenCalled()
+    expect(context.store.readEvents).not.toHaveBeenCalled()
+  })
+
+  it('honors persisted retry backoff before claiming a new lease', async () => {
+    const context = setup()
+    const nextAttemptAt = new Date('2026-08-03T15:00:30.000Z')
+    context.store.acquireLease.mockResolvedValue(null)
+    context.store.getCursor.mockResolvedValue({
+      ...context.storedCursor,
+      nextAttemptAt
+    })
+
+    await expect(
+      context.runner.runPartition('test-consumer', 'tenant-a')
+    ).resolves.toMatchObject({ status: 'backoff', nextAttemptAt })
+    expect(context.handle).not.toHaveBeenCalled()
+  })
+
+  it('isolates one consumer failure from other registered consumers', async () => {
+    const context = setup()
+    context.registry.register('second-consumer', {
+      types: ['content.updated'],
+      batchSize: 10,
+      maxAttempts: 3,
+      initialPosition: 'earliest',
+      handle: vi.fn()
+    })
+    context.store.initializeCursor
+      .mockRejectedValueOnce(new Error('first failed'))
+      .mockResolvedValueOnce(context.storedCursor)
+    context.store.readEvents.mockResolvedValue([])
+
+    await expect(context.runner.runTenant('tenant-a')).resolves.toEqual([
+      expect.objectContaining({ status: 'failed', consumer: 'test-consumer' }),
+      expect.objectContaining({ status: 'idle', consumer: 'second-consumer' })
+    ])
+    expect(context.logger.error).toHaveBeenCalledOnce()
+  })
+
+  it('caps exponential retry delay at the configured maximum', () => {
+    expect(
+      calculateRetryDelay(
+        { baseDelayMs: 1000, maxDelayMs: 5000, multiplier: 2 },
+        10
+      )
+    ).toBe(5000)
+  })
+})

--- a/apps/api/src/lib/domainEventConsumerStore.js
+++ b/apps/api/src/lib/domainEventConsumerStore.js
@@ -1,0 +1,464 @@
+const { mongoose } = require('@contexthub/common');
+
+const EVENT_COLLECTION = 'DomainEvents';
+const CURSOR_COLLECTION = 'DomainEventCursors';
+const DEAD_LETTER_COLLECTION = 'DomainEventDeadLetters';
+const DEFAULT_LEASE_DURATION_MS = 30 * 1000;
+
+class DomainEventConsumerStoreError extends Error {
+  constructor(message, code = 'DOMAIN_EVENT_CONSUMER_STORE_ERROR') {
+    super(message);
+    this.name = 'DomainEventConsumerStoreError';
+    this.code = code;
+  }
+}
+
+class DomainEventConsumerLeaseLostError extends DomainEventConsumerStoreError {
+  constructor(message) {
+    super(message, 'DOMAIN_EVENT_CONSUMER_LEASE_LOST');
+    this.name = 'DomainEventConsumerLeaseLostError';
+  }
+}
+
+function getConnectedDb() {
+  const connection = mongoose.connection;
+  if (!connection || !connection.db) {
+    throw new DomainEventConsumerStoreError(
+      'MongoDB connection is not ready',
+      'DOMAIN_EVENT_CONSUMER_DB_NOT_READY'
+    );
+  }
+  return connection.db;
+}
+
+function unwrapDocument(result) {
+  return result?.value ?? result ?? null;
+}
+
+function normalizeTenantId(tenantId) {
+  const normalized = String(tenantId ?? '').trim();
+  if (!normalized) {
+    throw new DomainEventConsumerStoreError(
+      'tenantId is required',
+      'DOMAIN_EVENT_CONSUMER_TENANT_REQUIRED'
+    );
+  }
+  return normalized;
+}
+
+function normalizeOwnerId(ownerId) {
+  const normalized = String(ownerId ?? '').trim();
+  if (!normalized) {
+    throw new DomainEventConsumerStoreError(
+      'lease ownerId is required',
+      'DOMAIN_EVENT_CONSUMER_OWNER_REQUIRED'
+    );
+  }
+  return normalized;
+}
+
+function partitionForTenant(tenantId) {
+  return `tenant:${normalizeTenantId(tenantId)}`;
+}
+
+function isDuplicateKeyError(error) {
+  return error?.code === 11000;
+}
+
+function assertLeaseMutation(result, action) {
+  if (!result?.matchedCount) {
+    throw new DomainEventConsumerLeaseLostError(
+      `consumer lease was lost before ${action}`
+    );
+  }
+}
+
+function createDomainEventConsumerStore(options = {}) {
+  const clock = options.clock || (() => new Date());
+  const leaseDurationMs =
+    options.leaseDurationMs ?? DEFAULT_LEASE_DURATION_MS;
+  if (!Number.isSafeInteger(leaseDurationMs) || leaseDurationMs < 1000) {
+    throw new DomainEventConsumerStoreError(
+      'leaseDurationMs must be an integer of at least 1000'
+    );
+  }
+
+  const resolveDb = () => options.db || getConnectedDb();
+  const collections = () => {
+    const db = resolveDb();
+    return {
+      events: db.collection(EVENT_COLLECTION),
+      cursors: db.collection(CURSOR_COLLECTION),
+      deadLetters: db.collection(DEAD_LETTER_COLLECTION)
+    };
+  };
+
+  const timestamp = () => {
+    const value = clock();
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      throw new DomainEventConsumerStoreError('clock returned an invalid date');
+    }
+    return date;
+  };
+
+  async function getHighWatermark(tenantId) {
+    const normalizedTenantId = normalizeTenantId(tenantId);
+    const { events } = collections();
+    const event = await events.findOne(
+      { tenantId: normalizedTenantId, sequence: { $type: 'number' } },
+      { sort: { sequence: -1 }, projection: { sequence: 1 } }
+    );
+    return Number.isSafeInteger(event?.sequence) ? event.sequence : 0;
+  }
+
+  async function getCursor(consumer, tenantId) {
+    const partition = partitionForTenant(tenantId);
+    const { cursors } = collections();
+    return cursors.findOne({ consumer, partition });
+  }
+
+  async function initializeCursor(registration, tenantId) {
+    const normalizedTenantId = normalizeTenantId(tenantId);
+    const partition = partitionForTenant(normalizedTenantId);
+    const { cursors } = collections();
+    const existing = await cursors.findOne({
+      consumer: registration.name,
+      partition
+    });
+    if (existing) {
+      if (existing.initialPosition !== registration.initialPosition) {
+        throw new DomainEventConsumerStoreError(
+          `consumer initialPosition changed after cursor creation: ${registration.name}`,
+          'DOMAIN_EVENT_CONSUMER_CONFIG_DRIFT'
+        );
+      }
+      return existing;
+    }
+
+    const now = timestamp();
+    const requiresWatermark = registration.initialPosition !== 'earliest';
+    const highWatermark = requiresWatermark
+      ? await getHighWatermark(normalizedTenantId)
+      : null;
+    const lastSequence = requiresWatermark ? highWatermark : 0;
+    const backfillStatus =
+      registration.initialPosition === 'backfill' ? 'pending' : null;
+    try {
+      await cursors.updateOne(
+        { consumer: registration.name, partition },
+        {
+          $setOnInsert: {
+            consumer: registration.name,
+            partition,
+            active: true,
+            initialPosition: registration.initialPosition,
+            lastSequence,
+            highWatermark,
+            backfillStatus,
+            backfillCompletedAt: null,
+            leaseOwner: null,
+            leaseUntil: null,
+            failureSequence: null,
+            attempt: 0,
+            nextAttemptAt: null,
+            lastError: null,
+            createdAt: now,
+            updatedAt: now
+          }
+        },
+        { upsert: true }
+      );
+    } catch (error) {
+      if (!isDuplicateKeyError(error)) throw error;
+    }
+
+    const cursor = await cursors.findOne({
+      consumer: registration.name,
+      partition
+    });
+    if (!cursor) {
+      throw new DomainEventConsumerStoreError(
+        `failed to initialize cursor: ${registration.name}/${partition}`
+      );
+    }
+    if (cursor.initialPosition !== registration.initialPosition) {
+      throw new DomainEventConsumerStoreError(
+        `consumer initialPosition changed after cursor creation: ${registration.name}`,
+        'DOMAIN_EVENT_CONSUMER_CONFIG_DRIFT'
+      );
+    }
+    return cursor;
+  }
+
+  async function acquireLease(registration, tenantId, ownerId) {
+    const partition = partitionForTenant(tenantId);
+    const owner = normalizeOwnerId(ownerId);
+    const now = timestamp();
+    const leaseUntil = new Date(now.getTime() + leaseDurationMs);
+    const { cursors } = collections();
+    const result = await cursors.findOneAndUpdate(
+      {
+        consumer: registration.name,
+        partition,
+        active: true,
+        backfillStatus: { $in: [null, 'completed'] },
+        $and: [
+          {
+            $or: [
+              { nextAttemptAt: null },
+              { nextAttemptAt: { $exists: false } },
+              { nextAttemptAt: { $lte: now } }
+            ]
+          },
+          {
+            $or: [
+              { leaseOwner: owner },
+              { leaseUntil: null },
+              { leaseUntil: { $exists: false } },
+              { leaseUntil: { $lte: now } }
+            ]
+          }
+        ]
+      },
+      {
+        $set: { leaseOwner: owner, leaseUntil, updatedAt: now }
+      },
+      { returnDocument: 'after' }
+    );
+
+    return unwrapDocument(result);
+  }
+
+  async function renewLease(cursor, ownerId, expectedLastSequence) {
+    const owner = normalizeOwnerId(ownerId);
+    const now = timestamp();
+    const leaseUntil = new Date(now.getTime() + leaseDurationMs);
+    const { cursors } = collections();
+    const result = await cursors.updateOne(
+      {
+        _id: cursor._id,
+        active: true,
+        leaseOwner: owner,
+        lastSequence: expectedLastSequence
+      },
+      { $set: { leaseUntil, updatedAt: now } }
+    );
+    assertLeaseMutation(result, 'renewal');
+    return leaseUntil;
+  }
+
+  async function releaseLease(cursor, ownerId) {
+    const owner = normalizeOwnerId(ownerId);
+    const now = timestamp();
+    const { cursors } = collections();
+    const result = await cursors.updateOne(
+      { _id: cursor._id, leaseOwner: owner },
+      {
+        $set: { leaseOwner: null, leaseUntil: null, updatedAt: now }
+      }
+    );
+    return Boolean(result?.matchedCount);
+  }
+
+  async function readEvents(registration, tenantId, lastSequence) {
+    const normalizedTenantId = normalizeTenantId(tenantId);
+    const { events } = collections();
+    return events
+      .find({
+        tenantId: normalizedTenantId,
+        type: { $in: registration.types },
+        sequence: { $gt: lastSequence }
+      })
+      .sort({ sequence: 1 })
+      .limit(registration.batchSize)
+      .toArray();
+  }
+
+  async function advanceCursor(
+    cursor,
+    ownerId,
+    expectedLastSequence,
+    nextSequence
+  ) {
+    if (!Number.isSafeInteger(nextSequence) || nextSequence <= expectedLastSequence) {
+      throw new DomainEventConsumerStoreError(
+        'next cursor sequence must be greater than the current sequence'
+      );
+    }
+
+    const owner = normalizeOwnerId(ownerId);
+    const now = timestamp();
+    const { cursors } = collections();
+    const result = await cursors.updateOne(
+      {
+        _id: cursor._id,
+        active: true,
+        leaseOwner: owner,
+        lastSequence: expectedLastSequence
+      },
+      {
+        $set: {
+          lastSequence: nextSequence,
+          leaseOwner: null,
+          leaseUntil: null,
+          failureSequence: null,
+          attempt: 0,
+          nextAttemptAt: null,
+          lastError: null,
+          updatedAt: now
+        }
+      }
+    );
+    assertLeaseMutation(result, 'cursor advancement');
+  }
+
+  async function scheduleRetry({
+    cursor,
+    ownerId,
+    expectedLastSequence,
+    eventSequence,
+    attempt,
+    nextAttemptAt,
+    error
+  }) {
+    const owner = normalizeOwnerId(ownerId);
+    const now = timestamp();
+    const { cursors } = collections();
+    const result = await cursors.updateOne(
+      {
+        _id: cursor._id,
+        active: true,
+        leaseOwner: owner,
+        lastSequence: expectedLastSequence
+      },
+      {
+        $set: {
+          failureSequence: eventSequence,
+          attempt,
+          nextAttemptAt,
+          lastError: error,
+          leaseOwner: null,
+          leaseUntil: null,
+          updatedAt: now
+        }
+      }
+    );
+    assertLeaseMutation(result, 'retry scheduling');
+  }
+
+  async function persistDeadLetter({
+    registration,
+    cursor,
+    tenantId,
+    event,
+    attempt,
+    error
+  }) {
+    const normalizedTenantId = normalizeTenantId(tenantId);
+    const now = timestamp();
+    const { deadLetters } = collections();
+    await deadLetters.updateOne(
+      {
+        consumer: registration.name,
+        partition: cursor.partition,
+        eventSequence: event.sequence
+      },
+      {
+        $setOnInsert: {
+          consumer: registration.name,
+          partition: cursor.partition,
+          eventId: event.id,
+          eventSequence: event.sequence,
+          tenantId: normalizedTenantId,
+          eventType: event.type,
+          event,
+          failedAt: now,
+          resolvedAt: null,
+          resolution: null,
+          createdAt: now
+        },
+        $set: { attempts: attempt, error, updatedAt: now }
+      },
+      { upsert: true }
+    );
+  }
+
+  async function readDeadLetterSequences(registration, cursor, eventSequences) {
+    if (!eventSequences.length) return new Set();
+    const { deadLetters } = collections();
+    const docs = await deadLetters
+      .find(
+        {
+          consumer: registration.name,
+          partition: cursor.partition,
+          eventSequence: { $in: eventSequences },
+          resolvedAt: null
+        },
+        { projection: { eventSequence: 1 } }
+      )
+      .toArray();
+    return new Set(docs.map((doc) => doc.eventSequence));
+  }
+
+  async function completeBackfill(registration, tenantId, highWatermark) {
+    const partition = partitionForTenant(tenantId);
+    const now = timestamp();
+    const { cursors } = collections();
+    const result = await cursors.updateOne(
+      {
+        consumer: registration.name,
+        partition,
+        initialPosition: 'backfill',
+        backfillStatus: 'pending',
+        highWatermark
+      },
+      {
+        $set: {
+          backfillStatus: 'completed',
+          backfillCompletedAt: now,
+          updatedAt: now
+        }
+      }
+    );
+    if (!result?.matchedCount) {
+      throw new DomainEventConsumerStoreError(
+        `backfill cursor did not match high watermark: ${registration.name}/${partition}`,
+        'DOMAIN_EVENT_CONSUMER_BACKFILL_MISMATCH'
+      );
+    }
+  }
+
+  return Object.freeze({
+    acquireLease,
+    advanceCursor,
+    completeBackfill,
+    getCursor,
+    getHighWatermark,
+    initializeCursor,
+    persistDeadLetter,
+    readDeadLetterSequences,
+    readEvents,
+    releaseLease,
+    renewLease,
+    scheduleRetry
+  });
+}
+
+module.exports = {
+  CURSOR_COLLECTION,
+  DEAD_LETTER_COLLECTION,
+  DEFAULT_LEASE_DURATION_MS,
+  EVENT_COLLECTION,
+  DomainEventConsumerLeaseLostError,
+  DomainEventConsumerStoreError,
+  createDomainEventConsumerStore,
+  partitionForTenant,
+  __testables: {
+    assertLeaseMutation,
+    isDuplicateKeyError,
+    normalizeOwnerId,
+    normalizeTenantId,
+    unwrapDocument
+  }
+};

--- a/apps/api/src/lib/domainEventConsumerStore.test.js
+++ b/apps/api/src/lib/domainEventConsumerStore.test.js
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  DomainEventConsumerLeaseLostError,
+  createDomainEventConsumerStore
+} from './domainEventConsumerStore'
+
+const registration = Object.freeze({
+  name: 'semantic-search-indexer',
+  types: Object.freeze(['content.published', 'content.updated']),
+  batchSize: 100,
+  initialPosition: 'latest'
+})
+
+function createCollections() {
+  const events = {
+    findOne: vi.fn(),
+    find: vi.fn()
+  }
+  const cursors = {
+    findOne: vi.fn(),
+    findOneAndUpdate: vi.fn(),
+    updateOne: vi.fn()
+  }
+  const deadLetters = {
+    find: vi.fn(),
+    updateOne: vi.fn()
+  }
+  const db = {
+    collection: vi.fn((name) => {
+      if (name === 'DomainEvents') return events
+      if (name === 'DomainEventCursors') return cursors
+      if (name === 'DomainEventDeadLetters') return deadLetters
+      throw new Error(`Unexpected collection: ${name}`)
+    })
+  }
+  return { db, events, cursors, deadLetters }
+}
+
+describe('domain event consumer store', () => {
+  it('initializes latest from the tenant inserted-event high watermark', async () => {
+    const { db, events, cursors } = createCollections()
+    const now = new Date('2026-08-03T14:00:00.000Z')
+    const initialized = {
+      _id: 'cursor-1',
+      consumer: registration.name,
+      partition: 'tenant:tenant-a',
+      initialPosition: 'latest',
+      lastSequence: 17,
+      highWatermark: 17
+    }
+    cursors.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(initialized)
+    cursors.updateOne.mockResolvedValue({ matchedCount: 0, upsertedCount: 1 })
+    events.findOne.mockResolvedValue({ sequence: 17 })
+    const store = createDomainEventConsumerStore({ db, clock: () => now })
+
+    await expect(store.initializeCursor(registration, 'tenant-a')).resolves.toBe(
+      initialized
+    )
+    expect(events.findOne).toHaveBeenCalledWith(
+      { tenantId: 'tenant-a', sequence: { $type: 'number' } },
+      { sort: { sequence: -1 }, projection: { sequence: 1 } }
+    )
+    expect(cursors.updateOne).toHaveBeenCalledWith(
+      { consumer: registration.name, partition: 'tenant:tenant-a' },
+      expect.objectContaining({
+        $setOnInsert: expect.objectContaining({
+          lastSequence: 17,
+          highWatermark: 17,
+          initialPosition: 'latest'
+        })
+      }),
+      { upsert: true }
+    )
+  })
+
+  it('fails fast when a persisted cursor start policy drifts', async () => {
+    const { db, cursors } = createCollections()
+    cursors.findOne.mockResolvedValue({
+      consumer: registration.name,
+      partition: 'tenant:tenant-a',
+      initialPosition: 'earliest'
+    })
+    const store = createDomainEventConsumerStore({ db })
+
+    await expect(
+      store.initializeCursor(registration, 'tenant-a')
+    ).rejects.toMatchObject({ code: 'DOMAIN_EVENT_CONSUMER_CONFIG_DRIFT' })
+  })
+
+  it('claims a due, expired tenant lease with owner-token CAS', async () => {
+    const { db, cursors } = createCollections()
+    const now = new Date('2026-08-03T14:00:00.000Z')
+    const claimed = { _id: 'cursor-1', leaseOwner: 'runner-1' }
+    cursors.findOneAndUpdate.mockResolvedValue({ value: claimed })
+    const store = createDomainEventConsumerStore({
+      db,
+      clock: () => now,
+      leaseDurationMs: 30000
+    })
+
+    await expect(
+      store.acquireLease(registration, 'tenant-a', 'runner-1')
+    ).resolves.toBe(claimed)
+    expect(cursors.findOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        consumer: registration.name,
+        partition: 'tenant:tenant-a',
+        active: true,
+        backfillStatus: { $in: [null, 'completed'] },
+        $and: expect.any(Array)
+      }),
+      {
+        $set: {
+          leaseOwner: 'runner-1',
+          leaseUntil: new Date('2026-08-03T14:00:30.000Z'),
+          updatedAt: now
+        }
+      },
+      { returnDocument: 'after' }
+    )
+  })
+
+  it('reads sequence-ordered tenant events without webhook status filtering', async () => {
+    const { db, events } = createCollections()
+    const toArray = vi.fn().mockResolvedValue([])
+    const limit = vi.fn(() => ({ toArray }))
+    const sort = vi.fn(() => ({ limit }))
+    events.find.mockReturnValue({ sort })
+    const store = createDomainEventConsumerStore({ db })
+
+    await store.readEvents(registration, 'tenant-a', 12)
+
+    expect(events.find).toHaveBeenCalledWith({
+      tenantId: 'tenant-a',
+      type: { $in: registration.types },
+      sequence: { $gt: 12 }
+    })
+    expect(sort).toHaveBeenCalledWith({ sequence: 1 })
+    expect(limit).toHaveBeenCalledWith(100)
+  })
+
+  it('uses owner and expected sequence when advancing the cursor', async () => {
+    const { db, cursors } = createCollections()
+    cursors.updateOne.mockResolvedValue({ matchedCount: 1, modifiedCount: 1 })
+    const store = createDomainEventConsumerStore({ db })
+
+    await store.advanceCursor(
+      { _id: 'cursor-1' },
+      'runner-1',
+      12,
+      15
+    )
+
+    expect(cursors.updateOne).toHaveBeenCalledWith(
+      {
+        _id: 'cursor-1',
+        active: true,
+        leaseOwner: 'runner-1',
+        lastSequence: 12
+      },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          lastSequence: 15,
+          leaseOwner: null,
+          attempt: 0
+        })
+      })
+    )
+  })
+
+  it('rejects stale-owner cursor advancement', async () => {
+    const { db, cursors } = createCollections()
+    cursors.updateOne.mockResolvedValue({ matchedCount: 0, modifiedCount: 0 })
+    const store = createDomainEventConsumerStore({ db })
+
+    await expect(
+      store.advanceCursor({ _id: 'cursor-1' }, 'old-runner', 12, 13)
+    ).rejects.toBeInstanceOf(DomainEventConsumerLeaseLostError)
+  })
+
+  it('persists an idempotent consumer-specific dead letter', async () => {
+    const { db, deadLetters } = createCollections()
+    deadLetters.updateOne.mockResolvedValue({ upsertedCount: 1 })
+    const store = createDomainEventConsumerStore({ db })
+    const event = {
+      id: 'event-13',
+      sequence: 13,
+      tenantId: 'tenant-a',
+      type: 'content.updated'
+    }
+
+    await store.persistDeadLetter({
+      registration,
+      cursor: { partition: 'tenant:tenant-a' },
+      tenantId: 'tenant-a',
+      event,
+      attempt: 8,
+      error: { name: 'Error', message: 'poison' }
+    })
+
+    expect(deadLetters.updateOne).toHaveBeenCalledWith(
+      {
+        consumer: registration.name,
+        partition: 'tenant:tenant-a',
+        eventSequence: 13
+      },
+      expect.objectContaining({
+        $setOnInsert: expect.objectContaining({
+          eventId: 'event-13',
+          eventSequence: 13,
+          event
+        }),
+        $set: expect.objectContaining({ attempts: 8 })
+      }),
+      { upsert: true }
+    )
+  })
+})

--- a/packages/common/src/models/DomainEvent.js
+++ b/packages/common/src/models/DomainEvent.js
@@ -44,6 +44,10 @@ domainEventSchema.index(
   { partialFilterExpression: { sequence: { $type: 'number' } } }
 );
 domainEventSchema.index(
+  { tenantId: 1, type: 1, sequence: 1 },
+  { partialFilterExpression: { sequence: { $type: 'number' } } }
+);
+domainEventSchema.index(
   { createdAt: 1 },
   { expireAfterSeconds: DOMAIN_EVENT_RETENTION_SECONDS }
 );

--- a/packages/common/src/models/DomainEventCursor.js
+++ b/packages/common/src/models/DomainEventCursor.js
@@ -14,6 +14,12 @@ const domainEventCursorSchema = new Schema(
     },
     lastSequence: { type: Number, min: 0, default: 0 },
     highWatermark: { type: Number, min: 0, default: null },
+    backfillStatus: {
+      type: String,
+      enum: ['pending', 'completed', 'failed'],
+      default: null
+    },
+    backfillCompletedAt: { type: Date, default: null },
     leaseOwner: { type: String, default: null },
     leaseUntil: { type: Date, default: null },
     failureSequence: { type: Number, min: 1, default: null },

--- a/packages/common/src/models/domainEventDeliveryModels.test.mjs
+++ b/packages/common/src/models/domainEventDeliveryModels.test.mjs
@@ -14,12 +14,20 @@ describe('domain event delivery models', () => {
       tenantId: 1,
       sequence: 1
     });
+    const tenantTypeSequence = findIndex(models.DomainEvent, {
+      tenantId: 1,
+      type: 1,
+      sequence: 1
+    });
 
     expect(globalSequence?.[1]).toMatchObject({
       unique: true,
       partialFilterExpression: { sequence: { $type: 'number' } }
     });
     expect(tenantSequence?.[1]).toMatchObject({
+      partialFilterExpression: { sequence: { $type: 'number' } }
+    });
+    expect(tenantTypeSequence?.[1]).toMatchObject({
       partialFilterExpression: { sequence: { $type: 'number' } }
     });
     expect(models.DomainEvent.schema.path('sequence').isRequired).toBeFalsy();
@@ -32,6 +40,9 @@ describe('domain event delivery models', () => {
     expect(
       findIndex(models.DomainEventCursor, { consumer: 1, partition: 1 })?.[1]
     ).toMatchObject({ unique: true });
+    expect(models.DomainEventCursor.schema.path('backfillStatus').enumValues).toEqual(
+      ['pending', 'completed', 'failed']
+    );
   });
 
   it('deduplicates dead letters by consumer partition and event sequence', () => {


### PR DESCRIPTION
## What changed

- add fail-fast `register(name, config)` consumer registry validation
- validate event types, batch size, max attempts, retry policy and explicit
  `earliest`/`latest`/`backfill` start policy
- initialize tenant cursor high-watermarks without using webhook delivery state
- add owner-token Mongo lease claim, renewal, release and stale-owner cursor CAS
- deliver events in ascending sequence with at-least-once replay semantics
- schedule exponential retry without advancing the cursor
- persist consumer-specific DLQ records before advancing past poison events
- recover safely if the process crashes between DLQ persistence and cursor advancement
- hold backfill consumers until the captured snapshot watermark is explicitly completed
- add the tenant/type/sequence query index and contract tests

## Why

F2 commercial consumers need an ordered, tenant-isolated delivery mechanism that is
independent from the existing webhook `status` lifecycle. A handler may be invoked more
than once when a process crashes before cursor persistence, so consumer handlers remain
responsible for idempotency by event id/sequence.

## Runtime impact

This PR adds the registry, Mongo store and runner contracts but does not yet bootstrap
private plugins or attach consumer-mode startup to `cron:webhooks`; that seam belongs to
F1 extension bootstrap. Existing webhook processing is not modified.

Handlers receive one-event arrays within the configured read batch. This preserves the
batch-shaped public contract while isolating the exact poison event for retry and DLQ.

## Validation

- `corepack pnpm version:check`
- `corepack pnpm lint`
- `corepack pnpm test`
- 116 tests passed: API 96, common 8, admin 10, promo SDK 2
- registry collision, lease CAS, backoff, max-attempt DLQ, DLQ-first crash recovery and
  handler-success/cursor-crash replay covered by tests
