### PR TITLE
feat: add versioned API plugin host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,10 @@ WEBHOOK_RETRY_BACKOFF_MS=60000
 WEBHOOK_FAILED_CLEANUP_MS=604800000 # 7 days
 SCHEDULED_PUBLISH_LIMIT=50
 
+# Optional extension manifests. Prefer a JSON array of absolute paths in composed
+# deployments; comma-separated paths are accepted for simple local development.
+CTXHUB_PLUGINS=[]
+
 # Cron endpoint secret (for /api/cron/webhooks)
 # Generate a strong random token: openssl rand -hex 32
 CRON_SECRET_TOKEN=your-secret-token-here

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "db:migrate": "node scripts/migrate.js",
     "db:backfill-subscriptions": "node src/scripts/backfillTenantSubscriptions.js",
     "db:backfill-domain-event-sequences": "node scripts/backfill-domain-event-sequences.js",
+    "cron:consumers": "node scripts/consumer-cron.js",
     "db:seed-plans": "node src/scripts/seedSubscriptionPlans.js",
     "db:seed-flags": "node src/scripts/seedFeatureFlags.js",
     "edge:sync-kv": "node src/scripts/syncEdgeGatewayKv.js"
@@ -42,6 +43,7 @@
     "marked": "^16.4.2",
     "nodemailer": "^6.10.1",
     "redis": "^5.12.1",
+    "semver": "7.8.5",
     "sharp": "^0.33.5",
     "undici": "^6.27.0",
     "uuid": "^13.0.2",

--- a/apps/api/scripts/consumer-cron.js
+++ b/apps/api/scripts/consumer-cron.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+const path = require('node:path');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+
+const { database, mongoose, Tenant } = require('@contexthub/common');
+const {
+  createDomainEventConsumerRegistry
+} = require('../src/lib/domainEventConsumerRegistry');
+const {
+  createDomainEventConsumerRunner
+} = require('../src/lib/domainEventConsumerRunner');
+const { runConsumerBatch } = require('../src/lib/domainEventConsumerProcess');
+const { bootstrapExtensions } = require('../src/lib/pluginHost');
+
+const targetArg = process.argv.find((argument) => argument.startsWith('--tenant='));
+const targetTenant = targetArg ? targetArg.slice('--tenant='.length).trim() : null;
+
+async function fetchTenants() {
+  if (!targetTenant) {
+    return Tenant.find({ status: { $ne: 'archived' } }, '_id slug status').lean();
+  }
+
+  const query = mongoose.Types.ObjectId.isValid(targetTenant)
+    ? { _id: targetTenant }
+    : { slug: targetTenant };
+  const tenant = await Tenant.findOne(query, '_id slug status').lean();
+  return tenant ? [tenant] : [];
+}
+
+async function main() {
+  await database.connectDB();
+
+  const eventRegistry = createDomainEventConsumerRegistry();
+  const extensionHost = await bootstrapExtensions({
+    mode: 'consumer',
+    eventRegistry,
+    logger: console
+  });
+  const consumers = eventRegistry.list();
+  if (!consumers.length) {
+    console.log('[consumer-cron] No domain event consumers are configured');
+    return;
+  }
+
+  const tenants = await fetchTenants();
+  if (!tenants.length) {
+    console.warn('[consumer-cron] No matching tenants found');
+    return;
+  }
+
+  console.log('[consumer-cron] Extensions loaded', {
+    plugins: extensionHost.registry.inventory(),
+    consumers: consumers.map(({ name }) => name)
+  });
+  const runner = createDomainEventConsumerRunner({ registry: eventRegistry });
+  const summaries = await runConsumerBatch({ tenants, runner, logger: console });
+  console.log('[consumer-cron] Run summary', JSON.stringify(summaries, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error('[consumer-cron] Fatal error', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    try {
+      await database.disconnectDB();
+    } catch (error) {
+      console.error('[consumer-cron] Failed to close database connection', error);
+      process.exitCode = 1;
+    }
+  });

--- a/apps/api/src/lib/__fixtures__/dummy-plugin/index.mjs
+++ b/apps/api/src/lib/__fixtures__/dummy-plugin/index.mjs
@@ -1,0 +1,18 @@
+export async function registerApi(app, context) {
+  app.get('/ping', async () => ({
+    ok: true,
+    plugin: context.plugin.name,
+    apiVersion: context.version,
+    apiRevision: context.revision
+  }));
+}
+
+export async function registerConsumers(context) {
+  context.events.register('dummy-consumer', {
+    types: ['content.updated'],
+    batchSize: 10,
+    maxAttempts: 3,
+    initialPosition: 'earliest',
+    handle: async () => {}
+  });
+}

--- a/apps/api/src/lib/__fixtures__/dummy-plugin/plugin.manifest.json
+++ b/apps/api/src/lib/__fixtures__/dummy-plugin/plugin.manifest.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "name": "dummy",
+  "version": "0.1.0",
+  "coreVersionRange": ">=0.1.0 <0.2.0",
+  "apiVersion": 1,
+  "apiRevision": 1,
+  "adminApiVersion": 1,
+  "adminApiRevision": 1,
+  "eventSchemaVersion": 1,
+  "routePrefix": "/api/dummy",
+  "permissions": ["dummy.read"],
+  "featureKeys": ["dummy.enabled"],
+  "consumesDomainEvents": ["content.updated"],
+  "consumers": [
+    {
+      "name": "dummy-consumer",
+      "types": ["content.updated"]
+    }
+  ],
+  "entrypoints": {
+    "api": "./index.mjs"
+  }
+}

--- a/apps/api/src/lib/domainEventConsumerProcess.js
+++ b/apps/api/src/lib/domainEventConsumerProcess.js
@@ -1,0 +1,33 @@
+function tenantIdentity(tenant) {
+  const value = tenant && typeof tenant === 'object'
+    ? tenant._id ?? tenant.id
+    : tenant;
+  const tenantId = String(value ?? '').trim();
+  if (!tenantId) throw new Error('consumer process received a tenant without an id');
+  return tenantId;
+}
+
+async function runConsumerBatch(options) {
+  const tenants = options.tenants || [];
+  const runner = options.runner;
+  const logger = options.logger || console;
+  if (!runner || typeof runner.runTenant !== 'function') {
+    throw new Error('consumer runner with runTenant() is required');
+  }
+
+  const summaries = [];
+  for (const tenant of tenants) {
+    const tenantId = tenantIdentity(tenant);
+    const results = await runner.runTenant(tenantId);
+    const summary = Object.freeze({
+      tenantId,
+      slug: tenant?.slug || null,
+      results
+    });
+    summaries.push(summary);
+    logger.info('[domainEventConsumerProcess] Tenant processed', summary);
+  }
+  return Object.freeze(summaries);
+}
+
+module.exports = { runConsumerBatch, tenantIdentity };

--- a/apps/api/src/lib/domainEventConsumerProcess.test.js
+++ b/apps/api/src/lib/domainEventConsumerProcess.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { runConsumerBatch, tenantIdentity } from './domainEventConsumerProcess'
+
+describe('domain event consumer process', () => {
+  it('runs every registered consumer partition through the runner for each tenant', async () => {
+    const runTenant = vi.fn(async (tenantId) => [
+      { consumer: 'dummy-consumer', tenantId, status: 'processed' }
+    ])
+    const logger = { info: vi.fn() }
+
+    const result = await runConsumerBatch({
+      tenants: [{ _id: 'tenant-1', slug: 'first' }, { id: 'tenant-2' }],
+      runner: { runTenant },
+      logger
+    })
+
+    expect(runTenant).toHaveBeenNthCalledWith(1, 'tenant-1')
+    expect(runTenant).toHaveBeenNthCalledWith(2, 'tenant-2')
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({ tenantId: 'tenant-1', slug: 'first' })
+  })
+
+  it('rejects tenant records without an identity', () => {
+    expect(() => tenantIdentity({ slug: 'missing-id' })).toThrow(
+      'tenant without an id'
+    )
+  })
+})

--- a/apps/api/src/lib/extensionApi.js
+++ b/apps/api/src/lib/extensionApi.js
@@ -1,0 +1,84 @@
+const {
+  domainEventConsumerRegistry
+} = require('./domainEventConsumerRegistry');
+const {
+  EXTENSION_API_REVISION,
+  EXTENSION_API_VERSION
+} = require('./extensionContract');
+
+class ExtensionApiError extends Error {
+  constructor(message, code = 'EXTENSION_API_ERROR') {
+    super(message);
+    this.name = 'ExtensionApiError';
+    this.code = code;
+  }
+}
+
+function createEventFacade(manifest, eventRegistry) {
+  const declaredTypes = new Set(manifest.consumesDomainEvents);
+  const declaredConsumers = new Map(
+    manifest.consumers.map((item) => [item.name, new Set(item.types)])
+  );
+
+  return Object.freeze({
+    register(name, config) {
+      const consumerTypes = declaredConsumers.get(name);
+      if (!consumerTypes) {
+        throw new ExtensionApiError(
+          `consumer is not declared by plugin ${manifest.name}: ${name}`,
+          'EXTENSION_CONSUMER_NOT_DECLARED'
+        );
+      }
+      const undeclaredType = config?.types?.find((type) => !declaredTypes.has(type));
+      if (undeclaredType) {
+        throw new ExtensionApiError(
+          `event type is not declared by plugin ${manifest.name}: ${undeclaredType}`,
+          'EXTENSION_EVENT_NOT_DECLARED'
+        );
+      }
+      if (
+        !Array.isArray(config?.types) ||
+        config.types.length !== consumerTypes.size ||
+        config.types.some((type) => !consumerTypes.has(type))
+      ) {
+        throw new ExtensionApiError(
+          `consumer event types do not match manifest declaration: ${name}`,
+          'EXTENSION_CONSUMER_CONTRACT_MISMATCH'
+        );
+      }
+      return eventRegistry.register(name, config);
+    }
+  });
+}
+
+function createLoggerFacade(logger) {
+  const facade = {};
+  for (const level of ['debug', 'info', 'warn', 'error']) {
+    facade[level] = typeof logger[level] === 'function'
+      ? logger[level].bind(logger)
+      : () => {};
+  }
+  return Object.freeze(facade);
+}
+
+function createExtensionApi(options) {
+  const manifest = options.manifest;
+  const eventRegistry = options.eventRegistry || domainEventConsumerRegistry;
+  const logger = options.logger || console;
+
+  return Object.freeze({
+    version: EXTENSION_API_VERSION,
+    revision: EXTENSION_API_REVISION,
+    plugin: Object.freeze({ name: manifest.name, version: manifest.version }),
+    events: createEventFacade(manifest, eventRegistry),
+    log: createLoggerFacade(logger)
+  });
+}
+
+module.exports = {
+  EXTENSION_API_REVISION,
+  EXTENSION_API_VERSION,
+  ExtensionApiError,
+  createExtensionApi,
+  createLoggerFacade
+};

--- a/apps/api/src/lib/extensionContract.js
+++ b/apps/api/src/lib/extensionContract.js
@@ -1,0 +1,28 @@
+const EXTENSION_API_VERSION = 1;
+const EXTENSION_API_REVISION = 1;
+const ADMIN_EXTENSION_API_VERSION = 1;
+const ADMIN_EXTENSION_API_REVISION = 1;
+const DOMAIN_EVENT_SCHEMA_VERSION = 1;
+
+function createExtensionContractDescriptor(coreVersion) {
+  return Object.freeze({
+    schemaVersion: 1,
+    coreVersion,
+    contracts: Object.freeze({
+      extensionApiVersion: EXTENSION_API_VERSION,
+      extensionApiRevision: EXTENSION_API_REVISION,
+      adminApiVersion: ADMIN_EXTENSION_API_VERSION,
+      adminApiRevision: ADMIN_EXTENSION_API_REVISION,
+      eventSchemaVersion: DOMAIN_EVENT_SCHEMA_VERSION
+    })
+  });
+}
+
+module.exports = {
+  ADMIN_EXTENSION_API_REVISION,
+  ADMIN_EXTENSION_API_VERSION,
+  DOMAIN_EVENT_SCHEMA_VERSION,
+  EXTENSION_API_REVISION,
+  EXTENSION_API_VERSION,
+  createExtensionContractDescriptor
+};

--- a/apps/api/src/lib/extensionContract.test.js
+++ b/apps/api/src/lib/extensionContract.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ADMIN_EXTENSION_API_REVISION,
+  ADMIN_EXTENSION_API_VERSION,
+  DOMAIN_EVENT_SCHEMA_VERSION,
+  EXTENSION_API_REVISION,
+  EXTENSION_API_VERSION,
+  createExtensionContractDescriptor
+} from './extensionContract'
+
+describe('extension contract descriptor', () => {
+  it('is generated from the same constants used by the runtime host', () => {
+    expect(createExtensionContractDescriptor('0.1.0')).toEqual({
+      schemaVersion: 1,
+      coreVersion: '0.1.0',
+      contracts: {
+        extensionApiVersion: EXTENSION_API_VERSION,
+        extensionApiRevision: EXTENSION_API_REVISION,
+        adminApiVersion: ADMIN_EXTENSION_API_VERSION,
+        adminApiRevision: ADMIN_EXTENSION_API_REVISION,
+        eventSchemaVersion: DOMAIN_EVENT_SCHEMA_VERSION
+      }
+    })
+  })
+})

--- a/apps/api/src/lib/extensionRegistry.js
+++ b/apps/api/src/lib/extensionRegistry.js
@@ -1,0 +1,139 @@
+const RESERVED_ROUTE_PREFIXES = Object.freeze([
+  '/api/auth',
+  '/api/activities',
+  '/api/admin',
+  '/api/api-tokens',
+  '/api/api-usage-sync',
+  '/api/categories',
+  '/api/cron',
+  '/api/custom-field-definitions',
+  '/api/dashboard',
+  '/api/documentation',
+  '/api/feature-flags',
+  '/api/galleries',
+  '/api/mail',
+  '/api/public',
+  '/api/subscription-plans',
+  '/api/tags',
+  '/api/tenant',
+  '/api/tenant-settings',
+  '/api/users',
+  '/api/tenants',
+  '/api/contents',
+  '/api/collections',
+  '/api/forms',
+  '/api/media',
+  '/api/menus',
+  '/api/placements',
+  '/api/webhooks',
+  '/api/roles'
+]);
+
+class ExtensionRegistryError extends Error {
+  constructor(message, code = 'EXTENSION_REGISTRY_ERROR') {
+    super(message);
+    this.name = 'ExtensionRegistryError';
+    this.code = code;
+  }
+}
+
+function createExtensionRegistry(options = {}) {
+  const plugins = new Map();
+  const routePrefixes = new Map();
+  const permissions = new Map();
+  const featureKeys = new Map();
+  const consumers = new Map();
+  const reserved = new Set(options.reservedRoutePrefixes || RESERVED_ROUTE_PREFIXES);
+
+  const assertAvailable = (registry, value, pluginName, kind) => {
+    const owner = registry.get(value);
+    if (owner) {
+      throw new ExtensionRegistryError(
+        `${kind} collision: ${value} is declared by ${owner} and ${pluginName}`,
+        'EXTENSION_DECLARATION_COLLISION'
+      );
+    }
+  };
+
+  const assertRouteAvailable = (routePrefix, pluginName) => {
+    for (const [registeredPrefix, owner] of routePrefixes) {
+      if (
+        routePrefix === registeredPrefix ||
+        routePrefix.startsWith(`${registeredPrefix}/`) ||
+        registeredPrefix.startsWith(`${routePrefix}/`)
+      ) {
+        throw new ExtensionRegistryError(
+          `route prefix collision: ${routePrefix} overlaps ${registeredPrefix} declared by ${owner} and ${pluginName}`,
+          'EXTENSION_DECLARATION_COLLISION'
+        );
+      }
+    }
+  };
+
+  return Object.freeze({
+    registerManifest(manifest) {
+      if (plugins.has(manifest.name)) {
+        throw new ExtensionRegistryError(
+          `plugin name collision: ${manifest.name}`,
+          'EXTENSION_PLUGIN_COLLISION'
+        );
+      }
+      const reservedOwner = Array.from(reserved).find(
+        (prefix) =>
+          manifest.routePrefix === prefix || manifest.routePrefix.startsWith(`${prefix}/`)
+      );
+      if (reservedOwner) {
+        throw new ExtensionRegistryError(
+          `plugin route prefix is reserved by core (${reservedOwner}): ${manifest.routePrefix}`,
+          'EXTENSION_ROUTE_RESERVED'
+        );
+      }
+
+      assertRouteAvailable(manifest.routePrefix, manifest.name);
+      for (const permission of manifest.permissions) {
+        assertAvailable(permissions, permission, manifest.name, 'permission');
+      }
+      for (const featureKey of manifest.featureKeys) {
+        assertAvailable(featureKeys, featureKey, manifest.name, 'feature key');
+      }
+      for (const consumer of manifest.consumers) {
+        assertAvailable(consumers, consumer.name, manifest.name, 'consumer');
+      }
+
+      routePrefixes.set(manifest.routePrefix, manifest.name);
+      for (const permission of manifest.permissions) permissions.set(permission, manifest.name);
+      for (const featureKey of manifest.featureKeys) featureKeys.set(featureKey, manifest.name);
+      for (const consumer of manifest.consumers) consumers.set(consumer.name, manifest.name);
+      plugins.set(manifest.name, manifest);
+      return manifest;
+    },
+
+    getPlugin(name) {
+      return plugins.get(name) || null;
+    },
+
+    listPlugins() {
+      return Object.freeze(Array.from(plugins.values()));
+    },
+
+    inventory() {
+      return Object.freeze(
+        Array.from(plugins.values()).map((manifest) =>
+          Object.freeze({
+            name: manifest.name,
+            version: manifest.version,
+            routePrefix: manifest.routePrefix,
+            apiVersion: manifest.apiVersion,
+            apiRevision: manifest.apiRevision
+          })
+        )
+      );
+    }
+  });
+}
+
+module.exports = {
+  ExtensionRegistryError,
+  RESERVED_ROUTE_PREFIXES,
+  createExtensionRegistry
+};

--- a/apps/api/src/lib/pluginHost.js
+++ b/apps/api/src/lib/pluginHost.js
@@ -1,0 +1,303 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const semver = require('semver');
+const { DOMAIN_EVENT_TYPES } = require('@contexthub/common');
+const { createExtensionApi } = require('./extensionApi');
+const {
+  ADMIN_EXTENSION_API_REVISION,
+  ADMIN_EXTENSION_API_VERSION,
+  DOMAIN_EVENT_SCHEMA_VERSION,
+  EXTENSION_API_REVISION,
+  EXTENSION_API_VERSION
+} = require('./extensionContract');
+const { createExtensionRegistry } = require('./extensionRegistry');
+
+const CORE_PACKAGE_PATH = path.resolve(__dirname, '../../../../package.json');
+const PLUGIN_NAME_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const ROUTE_PREFIX_PATTERN = /^\/api\/[a-z][a-z0-9-]*(?:\/[a-z0-9-]+)*$/;
+
+class PluginHostError extends Error {
+  constructor(message, code = 'PLUGIN_HOST_ERROR') {
+    super(message);
+    this.name = 'PluginHostError';
+    this.code = code;
+  }
+}
+
+function fail(message, code = 'PLUGIN_MANIFEST_INVALID') {
+  throw new PluginHostError(message, code);
+}
+
+function requiredString(value, label) {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  if (!normalized) fail(`${label} is required`);
+  return normalized;
+}
+
+function positiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    fail(`${label} must be a positive integer`);
+  }
+  return value;
+}
+
+function uniqueStrings(value, label) {
+  if (!Array.isArray(value)) fail(`${label} must be an array`);
+  const normalized = value.map((item) => requiredString(item, `${label} item`));
+  if (new Set(normalized).size !== normalized.length) {
+    fail(`${label} must not contain duplicates`);
+  }
+  return Object.freeze(normalized);
+}
+
+function validateConsumers(value, consumedTypes) {
+  if (value === undefined) return Object.freeze([]);
+  if (!Array.isArray(value)) fail('consumers must be an array');
+  const names = new Set();
+  return Object.freeze(
+    value.map((consumer) => {
+      const name = requiredString(consumer?.name, 'consumer.name');
+      if (names.has(name)) fail(`duplicate consumer declaration: ${name}`);
+      names.add(name);
+      const types = uniqueStrings(consumer.types || [], `consumer ${name} types`);
+      const undeclared = types.find((type) => !consumedTypes.includes(type));
+      if (undeclared) {
+        fail(`consumer ${name} uses undeclared event type: ${undeclared}`);
+      }
+      return Object.freeze({ name, types });
+    })
+  );
+}
+
+function validatePluginManifest(raw, options = {}) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    fail('plugin manifest must be an object');
+  }
+  const coreVersion = options.coreVersion || '0.0.0';
+  const name = requiredString(raw.name, 'name');
+  if (!PLUGIN_NAME_PATTERN.test(name)) fail(`invalid plugin name: ${name}`);
+  const version = requiredString(raw.version, 'version');
+  if (!semver.valid(version)) fail(`invalid plugin version: ${version}`);
+  const coreVersionRange = requiredString(
+    raw.coreVersionRange || raw.coreRange,
+    'coreVersionRange'
+  );
+  if (!semver.validRange(coreVersionRange)) {
+    fail(`invalid coreVersionRange: ${coreVersionRange}`);
+  }
+  if (!semver.satisfies(coreVersion, coreVersionRange)) {
+    fail(
+      `plugin ${name}@${version} does not support core ${coreVersion}`,
+      'PLUGIN_CORE_VERSION_INCOMPATIBLE'
+    );
+  }
+
+  const apiVersion = positiveInteger(raw.apiVersion, 'apiVersion');
+  const apiRevision = positiveInteger(
+    raw.apiRevision ?? raw.minApiRevision,
+    'apiRevision'
+  );
+  if (apiVersion !== EXTENSION_API_VERSION || apiRevision > EXTENSION_API_REVISION) {
+    fail(
+      `plugin ${name} requires extension API ${apiVersion} revision ${apiRevision}`,
+      'PLUGIN_API_VERSION_INCOMPATIBLE'
+    );
+  }
+
+  const adminApiVersion = positiveInteger(raw.adminApiVersion, 'adminApiVersion');
+  const adminApiRevision = positiveInteger(
+    raw.adminApiRevision ?? raw.minAdminApiRevision,
+    'adminApiRevision'
+  );
+  if (
+    adminApiVersion !== ADMIN_EXTENSION_API_VERSION ||
+    adminApiRevision > ADMIN_EXTENSION_API_REVISION
+  ) {
+    fail(
+      `plugin ${name} requires admin extension API ${adminApiVersion} revision ${adminApiRevision}`,
+      'PLUGIN_ADMIN_API_VERSION_INCOMPATIBLE'
+    );
+  }
+  const eventSchemaVersion = positiveInteger(
+    raw.eventSchemaVersion,
+    'eventSchemaVersion'
+  );
+  if (eventSchemaVersion !== DOMAIN_EVENT_SCHEMA_VERSION) {
+    fail(
+      `plugin ${name} requires domain event schema ${eventSchemaVersion}`,
+      'PLUGIN_EVENT_SCHEMA_INCOMPATIBLE'
+    );
+  }
+  const routePrefix = requiredString(raw.routePrefix, 'routePrefix');
+  if (!ROUTE_PREFIX_PATTERN.test(routePrefix)) {
+    fail(`invalid routePrefix: ${routePrefix}`);
+  }
+  const permissions = uniqueStrings(raw.permissions || [], 'permissions');
+  const featureKeys = uniqueStrings(raw.featureKeys || [], 'featureKeys');
+  const consumesDomainEvents = uniqueStrings(
+    raw.consumesDomainEvents || [],
+    'consumesDomainEvents'
+  );
+  const unknownEvent = consumesDomainEvents.find(
+    (type) => !DOMAIN_EVENT_TYPES.includes(type)
+  );
+  if (unknownEvent) fail(`unsupported domain event type: ${unknownEvent}`);
+
+  const apiEntrypoint = requiredString(raw.entrypoints?.api, 'entrypoints.api');
+  const consumers = validateConsumers(raw.consumers, consumesDomainEvents);
+
+  return Object.freeze({
+    schemaVersion: positiveInteger(raw.schemaVersion ?? 1, 'schemaVersion'),
+    name,
+    version,
+    coreVersionRange,
+    apiVersion,
+    apiRevision,
+    adminApiVersion,
+    adminApiRevision,
+    eventSchemaVersion,
+    routePrefix,
+    permissions,
+    featureKeys,
+    consumesDomainEvents,
+    consumers,
+    entrypoints: Object.freeze({ api: apiEntrypoint, admin: raw.entrypoints?.admin || null })
+  });
+}
+
+function resolvePluginEntries(value = process.env.CTXHUB_PLUGINS || '') {
+  if (Array.isArray(value)) return value.map((item) => path.resolve(item));
+  const serialized = String(value).trim();
+  if (!serialized) return [];
+  if (serialized.startsWith('[')) {
+    let parsed;
+    try {
+      parsed = JSON.parse(serialized);
+    } catch {
+      fail('CTXHUB_PLUGINS must be a JSON array or a comma-separated list');
+    }
+    if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== 'string')) {
+      fail('CTXHUB_PLUGINS JSON value must be an array of manifest paths');
+    }
+    return parsed.map((item) => path.resolve(item));
+  }
+  return serialized
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map((item) => path.resolve(item));
+}
+
+async function getCoreVersion() {
+  const payload = JSON.parse(await fs.readFile(CORE_PACKAGE_PATH, 'utf8'));
+  if (!semver.valid(payload.version)) fail('core package version is invalid');
+  return payload.version;
+}
+
+async function loadPlugin(entry, coreVersion) {
+  const manifestPath = await fs.realpath(path.resolve(entry));
+  const pluginRoot = await fs.realpath(path.dirname(manifestPath));
+  const raw = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+  const manifest = validatePluginManifest(raw, { coreVersion });
+  const modulePath = await fs.realpath(path.resolve(pluginRoot, manifest.entrypoints.api));
+  const relative = path.relative(pluginRoot, modulePath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    fail(`plugin entrypoint escapes plugin root: ${manifest.name}`);
+  }
+  const loaded = await import(pathToFileURL(modulePath).href);
+  const api = loaded.default && typeof loaded.default === 'object'
+    ? { ...loaded.default, ...loaded }
+    : loaded;
+  validatePluginExports(api, manifest);
+  return { api, manifest, manifestPath, modulePath };
+}
+
+function validatePluginExports(api, manifest) {
+  if (typeof api.registerApi !== 'function') {
+    fail(
+      `plugin ${manifest.name} does not export registerApi`,
+      'PLUGIN_ENTRYPOINT_INVALID'
+    );
+  }
+  if (manifest.consumers.length && typeof api.registerConsumers !== 'function') {
+    fail(
+      `plugin ${manifest.name} declares consumers but does not export registerConsumers`,
+      'PLUGIN_ENTRYPOINT_INVALID'
+    );
+  }
+}
+
+function hookForMode(plugin, mode) {
+  const hook = mode === 'api' ? plugin.api.registerApi : plugin.api.registerConsumers;
+  if (mode === 'consumer' && !plugin.manifest.consumers.length && !hook) {
+    return async () => {};
+  }
+  if (typeof hook !== 'function') {
+    fail(
+      `plugin ${plugin.manifest.name} does not export ${mode === 'api' ? 'registerApi' : 'registerConsumers'}`,
+      'PLUGIN_ENTRYPOINT_INVALID'
+    );
+  }
+  return hook;
+}
+
+async function bootstrapExtensions(options = {}) {
+  const mode = options.mode;
+  if (!['api', 'consumer'].includes(mode)) {
+    throw new PluginHostError('bootstrap mode must be api or consumer');
+  }
+  const entries = resolvePluginEntries(options.entries);
+  const registry = options.registry || createExtensionRegistry();
+  if (!entries.length) return Object.freeze({ registry, plugins: Object.freeze([]) });
+  if (mode === 'api' && !options.app) {
+    throw new PluginHostError('Fastify app is required in api mode');
+  }
+
+  const coreVersion = options.coreVersion || await getCoreVersion();
+  const plugins = [];
+  for (const entry of entries) {
+    const plugin = await loadPlugin(entry, coreVersion);
+    registry.registerManifest(plugin.manifest);
+    plugins.push(plugin);
+  }
+
+  const preparedPlugins = plugins.map((plugin) => ({
+    plugin,
+    hook: hookForMode(plugin, mode)
+  }));
+
+  for (const { plugin, hook } of preparedPlugins) {
+    if (mode === 'api') {
+      await options.app.register(
+        async function extensionFastifyScope(scopedApp) {
+          const context = createExtensionApi({
+            manifest: plugin.manifest,
+            eventRegistry: options.eventRegistry,
+            logger: scopedApp.log
+          });
+          await hook(scopedApp, context);
+        },
+        { prefix: plugin.manifest.routePrefix }
+      );
+    } else {
+      const context = createExtensionApi({
+        manifest: plugin.manifest,
+        eventRegistry: options.eventRegistry,
+        logger: options.logger || console
+      });
+      await hook(context);
+    }
+  }
+
+  return Object.freeze({ registry, plugins: Object.freeze(plugins) });
+}
+
+module.exports = {
+  PluginHostError,
+  bootstrapExtensions,
+  loadPlugin,
+  resolvePluginEntries,
+  validatePluginExports,
+  validatePluginManifest
+};

--- a/apps/api/src/lib/pluginHost.test.js
+++ b/apps/api/src/lib/pluginHost.test.js
@@ -1,0 +1,212 @@
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import fastify from 'fastify'
+
+import { createDomainEventConsumerRegistry } from './domainEventConsumerRegistry'
+import { createExtensionRegistry } from './extensionRegistry'
+import {
+  bootstrapExtensions,
+  validatePluginExports,
+  validatePluginManifest
+} from './pluginHost'
+
+const dummyManifest = path.resolve(
+  process.cwd(),
+  'src/lib/__fixtures__/dummy-plugin/plugin.manifest.json'
+)
+
+function validManifest(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    name: 'test-plugin',
+    version: '0.1.0',
+    coreVersionRange: '>=0.1.0 <0.2.0',
+    apiVersion: 1,
+    apiRevision: 1,
+    adminApiVersion: 1,
+    adminApiRevision: 1,
+    eventSchemaVersion: 1,
+    routePrefix: '/api/test-plugin',
+    permissions: ['test.read'],
+    featureKeys: ['test.enabled'],
+    consumesDomainEvents: ['content.updated'],
+    consumers: [{ name: 'test-consumer', types: ['content.updated'] }],
+    entrypoints: { api: './index.js' },
+    ...overrides
+  }
+}
+
+describe('plugin host', () => {
+  it('boots a plugin in an isolated Fastify prefix', async () => {
+    const app = fastify({ logger: false })
+    const result = await bootstrapExtensions({
+      mode: 'api',
+      app,
+      entries: [dummyManifest],
+      coreVersion: '0.1.0'
+    })
+
+    const response = await app.inject({ method: 'GET', url: '/api/dummy/ping' })
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      ok: true,
+      plugin: 'dummy',
+      apiVersion: 1,
+      apiRevision: 1
+    })
+    expect(result.registry.inventory()).toEqual([
+      expect.objectContaining({ name: 'dummy', routePrefix: '/api/dummy' })
+    ])
+    await app.close()
+  })
+
+  it('registers declared consumers in consumer mode', async () => {
+    const eventRegistry = createDomainEventConsumerRegistry()
+
+    await bootstrapExtensions({
+      mode: 'consumer',
+      entries: [dummyManifest],
+      eventRegistry,
+      coreVersion: '0.1.0',
+      logger: { info: vi.fn(), error: vi.fn() }
+    })
+
+    expect(eventRegistry.get('dummy-consumer')).toMatchObject({
+      types: ['content.updated'],
+      initialPosition: 'earliest'
+    })
+  })
+
+  it('is a no-op when no plugins are configured', async () => {
+    const app = fastify({ logger: false })
+    const result = await bootstrapExtensions({
+      mode: 'api',
+      app,
+      entries: [],
+      coreVersion: '0.1.0'
+    })
+
+    expect(result.plugins).toEqual([])
+    expect(result.registry.inventory()).toEqual([])
+    await app.close()
+  })
+
+  it('rejects incompatible core and facade revisions', () => {
+    expect(() =>
+      validatePluginManifest(validManifest({ coreVersionRange: '>=1.0.0' }), {
+        coreVersion: '0.1.0'
+      })
+    ).toThrowError(expect.objectContaining({
+      code: 'PLUGIN_CORE_VERSION_INCOMPATIBLE'
+    }))
+    expect(() =>
+      validatePluginManifest(validManifest({ apiRevision: 2 }), {
+        coreVersion: '0.1.0'
+      })
+    ).toThrowError(expect.objectContaining({
+      code: 'PLUGIN_API_VERSION_INCOMPATIBLE'
+    }))
+    expect(() =>
+      validatePluginManifest(validManifest({ adminApiRevision: 2 }), {
+        coreVersion: '0.1.0'
+      })
+    ).toThrowError(expect.objectContaining({
+      code: 'PLUGIN_ADMIN_API_VERSION_INCOMPATIBLE'
+    }))
+    expect(() =>
+      validatePluginManifest(validManifest({ eventSchemaVersion: 2 }), {
+        coreVersion: '0.1.0'
+      })
+    ).toThrowError(expect.objectContaining({
+      code: 'PLUGIN_EVENT_SCHEMA_INCOMPATIBLE'
+    }))
+  })
+
+  it('requires numeric contract versions and parses JSON manifest path lists', async () => {
+    expect(() =>
+      validatePluginManifest(validManifest({ apiVersion: '1' }), {
+        coreVersion: '0.1.0'
+      })
+    ).toThrow('apiVersion must be a positive integer')
+
+    const { resolvePluginEntries } = await import('./pluginHost.js')
+    expect(resolvePluginEntries(JSON.stringify([dummyManifest]))).toEqual([dummyManifest])
+  })
+
+  it('requires consumer hooks whenever the manifest declares a consumer', () => {
+    const manifest = validatePluginManifest(validManifest(), { coreVersion: '0.1.0' })
+    expect(() => validatePluginExports({ registerApi() {} }, manifest)).toThrowError(
+      expect.objectContaining({ code: 'PLUGIN_ENTRYPOINT_INVALID' })
+    )
+  })
+
+  it('fails before registration hooks when declarations collide', async () => {
+    const app = fastify({ logger: false })
+
+    await expect(
+      bootstrapExtensions({
+        mode: 'api',
+        app,
+        entries: [dummyManifest, dummyManifest],
+        registry: createExtensionRegistry(),
+        coreVersion: '0.1.0'
+      })
+    ).rejects.toMatchObject({ code: 'EXTENSION_PLUGIN_COLLISION' })
+    await app.close()
+  })
+
+  it('rejects core route subpaths and overlapping plugin prefixes', () => {
+    const registry = createExtensionRegistry()
+    const first = validatePluginManifest(validManifest(), { coreVersion: '0.1.0' })
+    registry.registerManifest(first)
+
+    expect(() => registry.registerManifest(
+      validatePluginManifest(validManifest({
+        name: 'nested-plugin',
+        routePrefix: '/api/test-plugin/nested',
+        permissions: ['nested.read'],
+        featureKeys: ['nested.enabled'],
+        consumers: [{ name: 'nested-consumer', types: ['content.updated'] }]
+      }), { coreVersion: '0.1.0' })
+    )).toThrowError(expect.objectContaining({ code: 'EXTENSION_DECLARATION_COLLISION' }))
+
+    expect(() => createExtensionRegistry().registerManifest(
+      validatePluginManifest(validManifest({ routePrefix: '/api/auth/plugin' }), {
+        coreVersion: '0.1.0'
+      })
+    )).toThrowError(expect.objectContaining({ code: 'EXTENSION_ROUTE_RESERVED' }))
+  })
+
+  it('rejects unsupported or undeclared event contracts', () => {
+    expect(() =>
+      validatePluginManifest(
+        validManifest({ consumesDomainEvents: ['content.not-real'] }),
+        { coreVersion: '0.1.0' }
+      )
+    ).toThrow('unsupported domain event type')
+    expect(() =>
+      validatePluginManifest(
+        validManifest({
+          consumers: [{ name: 'test-consumer', types: ['content.deleted'] }]
+        }),
+        { coreVersion: '0.1.0' }
+      )
+    ).toThrow('uses undeclared event type')
+  })
+
+  it('enforces the consumer-specific event declaration at registration time', async () => {
+    const eventRegistry = createDomainEventConsumerRegistry()
+    const manifest = validatePluginManifest(validManifest(), { coreVersion: '0.1.0' })
+    const { createExtensionApi } = await import('./extensionApi.js')
+    const context = createExtensionApi({ manifest, eventRegistry, logger: {} })
+
+    expect(() => context.events.register('not-declared', {})).toThrowError(
+      expect.objectContaining({ code: 'EXTENSION_CONSUMER_NOT_DECLARED' })
+    )
+    expect(() => context.events.register('test-consumer', {
+      types: ['content.created']
+    })).toThrowError(
+      expect.objectContaining({ code: 'EXTENSION_EVENT_NOT_DECLARED' })
+    )
+  })
+})

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -14,6 +14,7 @@ const apiLogger = require('./middleware/apiLogger');
 const localRedisClient = require('./lib/localRedis');
 const { getSessionCookieName } = require('./services/sessionSecurity');
 const { resolveCorsOptions } = require('./services/tenantOriginPolicy');
+const { bootstrapExtensions } = require('./lib/pluginHost');
 
 // Load environment variables from a local .env file when present.  Production deployments should use secrets management instead.
 dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
@@ -82,7 +83,7 @@ const jwtPlugin = fp(async function (app) {
   });
 });
 
-async function buildServer() {
+async function buildServer(options = {}) {
   // Validate production cookie configuration during startup instead of failing
   // on the first login request.
   getSessionCookieName();
@@ -290,6 +291,12 @@ async function buildServer() {
   await app.register(require('./routes/apiTokens'), { prefix: '/api' });
   await app.register(require('./routes/webhooks'), { prefix: '/api' });
   await app.register(require('./routes/cronWebhooks'), { prefix: '/api' });
+
+  await bootstrapExtensions({
+    mode: 'api',
+    app,
+    entries: options.pluginEntries
+  });
 
   // Health check
   app.get('/health', async () => {

--- a/apps/api/src/server.test.mjs
+++ b/apps/api/src/server.test.mjs
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createRequire } from 'module';
+import path from 'node:path';
 
 const require = createRequire(import.meta.url);
 const AuthService = require('./services/authService');
@@ -55,7 +56,14 @@ describe('API server', () => {
       }
       throw new Error('Invalid credentials');
     };
-    app = await buildServer();
+    app = await buildServer({
+      pluginEntries: [
+        path.resolve(
+          process.cwd(),
+          'src/lib/__fixtures__/dummy-plugin/plugin.manifest.json'
+        )
+      ]
+    });
   });
   afterAll(async () => {
     if (app) await app.close();
@@ -74,6 +82,17 @@ describe('API server', () => {
     expect(body.status).toBe('ok');
     expect(res.headers['x-content-type-options']).toBe('nosniff');
     expect(res.headers['x-frame-options']).toBe('DENY');
+  });
+
+  it('boots configured API extensions under their declared prefix', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/dummy/ping' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.payload)).toMatchObject({
+      ok: true,
+      plugin: 'dummy',
+      apiVersion: 1,
+      apiRevision: 1
+    });
   });
 
   it('creates a tenant-selection session when tenantId is omitted', async () => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "Multi‑tenant headless CMS and content services platform.",
   "license": "MIT",
   "scripts": {
-    "start": "NODE_ENV=production node src/server.js",
+    "start": "NODE_ENV=production node apps/api/src/server.js",
     "dev": "turbo dev",
     "dev:api": "turbo dev --filter=@contexthub/api",
     "dev:admin": "turbo dev --filter=@contexthub/admin",
@@ -26,12 +26,14 @@
     "clean": "turbo clean",
     "version:set": "node scripts/set-version.mjs",
     "version:check": "node scripts/set-version.mjs --check",
+    "extension:contract": "node scripts/write-extension-contract.mjs",
     "create:index": "node scripts/create-indexes.mjs",
     "db:seed": "turbo dev --filter=@contexthub/api -- --seed",
     "db:migrate": "turbo dev --filter=@contexthub/api -- --migrate",
     "db:backfill-domain-event-sequences": "node apps/api/scripts/backfill-domain-event-sequences.js",
     "dispatch:webhooks": "node apps/api/scripts/dispatch-webhooks.js",
-    "cron:webhooks": "node apps/api/scripts/webhook-cron.js"
+    "cron:webhooks": "node apps/api/scripts/webhook-cron.js",
+    "cron:consumers": "node apps/api/scripts/consumer-cron.js"
   },
   "workspaces": [
     "apps/*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       redis:
         specifier: ^5.12.1
         version: 5.12.1
+      semver:
+        specifier: 7.8.5
+        version: 7.8.5
       sharp:
         specifier: ^0.33.5
         version: 0.33.5

--- a/scripts/write-extension-contract.mjs
+++ b/scripts/write-extension-contract.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const { createExtensionContractDescriptor } = require(
+  '../apps/api/src/lib/extensionContract'
+);
+const rootDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function outputArgument(args) {
+  const index = args.indexOf('--output');
+  if (index === -1) return null;
+  const value = args[index + 1];
+  if (!value) throw new Error('--output requires a file path');
+  return path.resolve(value);
+}
+
+async function main() {
+  const packageJson = JSON.parse(
+    await readFile(path.join(rootDirectory, 'package.json'), 'utf8')
+  );
+  const descriptor = createExtensionContractDescriptor(packageJson.version);
+  const serialized = `${JSON.stringify(descriptor, null, 2)}\n`;
+  const outputPath = outputArgument(process.argv.slice(2));
+
+  if (!outputPath) {
+    process.stdout.write(serialized);
+    return;
+  }
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, serialized, 'utf8');
+  console.log(`[extension-contract] Wrote ${outputPath}`);
+}
+
+main().catch((error) => {
+  console.error(`[extension-contract] ${error.message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add strict JSON plugin manifest validation, declaration registries, and fail-fast collision checks
- add versioned API/admin/event contract descriptor generation and an ESM dummy plugin contract suite
- bootstrap API plugins from CTXHUB_PLUGINS and register consumers in a separate cron process
- keep public health output unchanged and preserve no-plugin behavior

## Verification
- pnpm version:check
- pnpm lint
- pnpm test (all workspace tests pass; existing admin lint warnings remain)

## Follow-up
- read-only content/collection/schema facade adapters and namespaced cache
- authenticated release operations endpoint and private import boundary check
- commercial semantic-search register hooks after the data facade lands