### PR TITLE
fix(security): enforce edge origin credential

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ ALLOWED_HOSTS=api.example.com
 STRICT_HOST_CHECK=true
 REQUIRE_HTTPS=true
 
+# Edge-to-origin protection. Production refuses to start when this is disabled
+# or the secret is missing/short. Store the value in your deployment secret
+# manager; never commit the real shared secret.
+ORIGIN_PROTECTION_ENABLED=true
+ORIGIN_SHARED_SECRET=
+
 # Legacy CORS fallback. New deployments should define AUTH_TRUSTED_ORIGINS
 # explicitly and manage tenant website origins from each tenant's Edge API settings.
 CORS_ORIGIN=https://app.example.com

--- a/apps/api/src/middleware/originProtection.js
+++ b/apps/api/src/middleware/originProtection.js
@@ -1,0 +1,88 @@
+const crypto = require("crypto");
+
+const ORIGIN_SECRET_HEADER = "x-ctx-origin-secret";
+const MIN_ORIGIN_SECRET_BYTES = 32;
+
+function envFlag(value, defaultValue = false) {
+  if (value === undefined || value === null || value === "") {
+    return defaultValue;
+  }
+
+  return ["1", "true", "yes", "on"].includes(
+    String(value).trim().toLowerCase(),
+  );
+}
+
+function resolveOriginProtectionConfig(env = process.env) {
+  const isProduction = env.NODE_ENV === "production";
+  const enabled = envFlag(env.ORIGIN_PROTECTION_ENABLED, isProduction);
+
+  if (isProduction && !enabled) {
+    throw new Error(
+      "ORIGIN_PROTECTION_ENABLED cannot be disabled in production. Refusing to start.",
+    );
+  }
+
+  if (!enabled) {
+    return { enabled: false, secret: null };
+  }
+
+  const secret = env.ORIGIN_SHARED_SECRET;
+  if (!secret || Buffer.byteLength(secret, "utf8") < MIN_ORIGIN_SECRET_BYTES) {
+    throw new Error(
+      `ORIGIN_SHARED_SECRET must be set to at least ${MIN_ORIGIN_SECRET_BYTES} bytes when origin protection is enabled.`,
+    );
+  }
+
+  return { enabled: true, secret };
+}
+
+function timingSafeSecretEqual(provided, expected) {
+  if (typeof provided !== "string") {
+    return false;
+  }
+
+  const providedDigest = crypto
+    .createHash("sha256")
+    .update(provided, "utf8")
+    .digest();
+  const expectedDigest = crypto
+    .createHash("sha256")
+    .update(expected, "utf8")
+    .digest();
+  return crypto.timingSafeEqual(providedDigest, expectedDigest);
+}
+
+function createOriginProtectionHook(env = process.env) {
+  const config = resolveOriginProtectionConfig(env);
+
+  return async function verifyOriginRequest(request, reply) {
+    if (!config.enabled) {
+      return;
+    }
+
+    const provided = request.headers[ORIGIN_SECRET_HEADER];
+    if (!timingSafeSecretEqual(provided, config.secret)) {
+      const pathname = String(request.url || "").split("?", 1)[0];
+      request.log.warn(
+        { pathname, ip: request.ip },
+        "Blocked request without a valid origin credential",
+      );
+      return reply.code(403).header("Cache-Control", "private, no-store").send({
+        error: "OriginAccessDenied",
+        message: "Request rejected by origin policy.",
+      });
+    }
+
+    // Downstream routes, plugins and application logs do not need the credential.
+    delete request.headers[ORIGIN_SECRET_HEADER];
+  };
+}
+
+module.exports = {
+  MIN_ORIGIN_SECRET_BYTES,
+  ORIGIN_SECRET_HEADER,
+  createOriginProtectionHook,
+  resolveOriginProtectionConfig,
+  timingSafeSecretEqual,
+};

--- a/apps/api/src/middleware/originProtection.test.mjs
+++ b/apps/api/src/middleware/originProtection.test.mjs
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const fastify = require("fastify");
+const {
+  createOriginProtectionHook,
+  resolveOriginProtectionConfig,
+  timingSafeSecretEqual,
+} = require("./originProtection");
+
+const TEST_SECRET = "a-secure-origin-secret-with-at-least-32-bytes";
+const apps = [];
+
+async function buildApp(env) {
+  const app = fastify({ logger: false });
+  apps.push(app);
+  app.addHook("onRequest", createOriginProtectionHook(env));
+  app.get("/health", async (request) => ({
+    status: "ok",
+    secretVisibleToRoute: Boolean(request.headers["x-ctx-origin-secret"]),
+  }));
+  return app;
+}
+
+afterEach(async () => {
+  await Promise.all(apps.splice(0).map((app) => app.close()));
+});
+
+describe("originProtection", () => {
+  it("stays disabled by default outside production", () => {
+    expect(resolveOriginProtectionConfig({ NODE_ENV: "test" })).toEqual({
+      enabled: false,
+      secret: null,
+    });
+  });
+
+  it("cannot be disabled in production", () => {
+    expect(() =>
+      resolveOriginProtectionConfig({
+        NODE_ENV: "production",
+        ORIGIN_PROTECTION_ENABLED: "false",
+        ORIGIN_SHARED_SECRET: TEST_SECRET,
+      }),
+    ).toThrow("cannot be disabled in production");
+  });
+
+  it("refuses to start with a missing or short secret when enabled", () => {
+    expect(() =>
+      resolveOriginProtectionConfig({
+        NODE_ENV: "production",
+        ORIGIN_PROTECTION_ENABLED: "true",
+      }),
+    ).toThrow("ORIGIN_SHARED_SECRET");
+
+    expect(() =>
+      resolveOriginProtectionConfig({
+        NODE_ENV: "production",
+        ORIGIN_PROTECTION_ENABLED: "true",
+        ORIGIN_SHARED_SECRET: "too-short",
+      }),
+    ).toThrow("at least 32 bytes");
+  });
+
+  it("uses a timing-safe fixed-length digest comparison", () => {
+    expect(timingSafeSecretEqual(TEST_SECRET, TEST_SECRET)).toBe(true);
+    expect(timingSafeSecretEqual("wrong", TEST_SECRET)).toBe(false);
+    expect(timingSafeSecretEqual(undefined, TEST_SECRET)).toBe(false);
+  });
+
+  it("blocks health requests without a secret", async () => {
+    const app = await buildApp({
+      NODE_ENV: "production",
+      ORIGIN_PROTECTION_ENABLED: "true",
+      ORIGIN_SHARED_SECRET: TEST_SECRET,
+    });
+
+    const response = await app.inject({ method: "GET", url: "/health" });
+    expect(response.statusCode).toBe(403);
+    expect(response.headers["cache-control"]).toBe("private, no-store");
+    expect(response.json()).toMatchObject({ error: "OriginAccessDenied" });
+  });
+
+  it("blocks an incorrect secret", async () => {
+    const app = await buildApp({
+      NODE_ENV: "production",
+      ORIGIN_PROTECTION_ENABLED: "true",
+      ORIGIN_SHARED_SECRET: TEST_SECRET,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/health",
+      headers: { "x-ctx-origin-secret": "incorrect-secret" },
+    });
+    expect(response.statusCode).toBe(403);
+  });
+
+  it("allows a valid request and removes the credential before the route", async () => {
+    const app = await buildApp({
+      NODE_ENV: "production",
+      ORIGIN_PROTECTION_ENABLED: "true",
+      ORIGIN_SHARED_SECRET: TEST_SECRET,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/health",
+      headers: { "x-ctx-origin-secret": TEST_SECRET },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      status: "ok",
+      secretVisibleToRoute: false,
+    });
+  });
+});

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -11,6 +11,7 @@ const { database } = require('@contexthub/common');
 const roleService = require('./services/roleService');
 const tenantContext = require('@contexthub/common/src/tenantContext');
 const apiLogger = require('./middleware/apiLogger');
+const { createOriginProtectionHook } = require('./middleware/originProtection');
 const localRedisClient = require('./lib/localRedis');
 const { getSessionCookieName } = require('./services/sessionSecurity');
 const { resolveCorsOptions } = require('./services/tenantOriginPolicy');
@@ -95,6 +96,11 @@ async function buildServer() {
   // the intended cap.
   const maxParamLength = Number(process.env.API_MAX_PARAM_LENGTH) || 240;
   const app = fastify({ logger: true, trustProxy: true, bodyLimit, maxParamLength });
+
+  // Validate the edge-to-origin credential before CORS, auth, plugins or routes run.
+  // Production is fail-closed: startup fails when protection is disabled or the
+  // shared secret is missing/weak.
+  app.addHook('onRequest', createOriginProtectionHook());
 
   app.addHook('onSend', async (_request, reply, payload) => {
     reply.header('X-Content-Type-Options', 'nosniff');


### PR DESCRIPTION
## What changed

- Adds a fail-closed origin credential guard to the Node API.
- Requires origin protection in production and rejects missing or short secrets at startup.
- Uses a fixed-length SHA-256 digest with timing-safe comparison.
- Rejects missing/invalid `X-CTX-Origin-Secret` requests before CORS, auth, plugins, or routes.
- Documents the required production environment variables.

## Why

The origin API could previously be reached without the Cloudflare Edge Gateway credential, allowing edge controls to be bypassed if another network layer was misconfigured.

## Validation

- Production baseline (`70ff9b0`): 14 files / 63 API tests passed.
- Current `main` merge simulation: 23 files / 117 API tests passed.
- Targeted API lint passed.
- Live production probes confirm missing/invalid secret returns 403, valid Worker traffic returns 200.
