### PR TITLE
fix: remove metering work from the request hot path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,13 @@ R2_BUCKET=my-bucket
 REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
 
+# Kota bayragini tazeleyen zamanlanmis isin araligi (dakika).
+# Hot path kullanimi yeniden hesaplamaz, sadece bu isin yazdigi bayragi okur;
+# bu deger kotasi dolan bir tenant'in en fazla ne kadar fazladan servis
+# alabilecegini belirler. 0 = surec ici zamanlayici kapali, yalniz harici cron
+# (POST /api-usage-sync/trigger) kullanilir.
+USAGE_SYNC_INTERVAL_MINUTES=60
+
 # Webhook dispatcher & scheduler controls
 WEBHOOK_DISPATCH_LIMIT=50
 WEBHOOK_DISPATCH_INTERVAL_MS=5000

--- a/apps/api/src/lib/localRedis.js
+++ b/apps/api/src/lib/localRedis.js
@@ -272,13 +272,11 @@ class LocalRedisClient extends EventEmitter {
       return null;
     }
 
-    try {
-      const value = await this.client.get(this.getRequestLimitFlagKey(tenantId, cycleKey));
-      return value ? JSON.parse(value) : null;
-    } catch (error) {
-      console.error('[LocalRedis] Failed to get request limit flag:', error.message);
-      return null;
-    }
+    // The quota guard owns the fail-open policy and throttled warning. Preserve
+    // read/parse failures so it can distinguish an unavailable gate from a
+    // valid "not exceeded" result without logging on every request here.
+    const value = await this.client.get(this.getRequestLimitFlagKey(tenantId, cycleKey));
+    return value ? JSON.parse(value) : null;
   }
 
   async clearRequestLimitFlag(tenantId, cycleKey = getCurrentMonthKey()) {

--- a/apps/api/src/middleware/requestLimitGuard.js
+++ b/apps/api/src/middleware/requestLimitGuard.js
@@ -1,4 +1,4 @@
-const apiUsageService = require('../services/apiUsageService');
+const localRedisClient = require('../lib/localRedis');
 
 const SKIP_PATH_PREFIXES = [
   '/health',
@@ -12,6 +12,28 @@ const SKIP_PATH_REGEXES = [
   /^\/api\/tenants\/[^/]+\/subscription/,
   /^\/api\/tenants\/[^/]+\/limits/,
 ];
+
+// Kota kapisi okunamadiginda istek gecirilir (bilincli fail-open): kullanim
+// sayaci bir olcumdur, yetki degildir. Redis coktugu icin butun musterileri
+// kesmek, birkac saat fazla servis etmekten daha kotudur. Askiya alma veya plan
+// dusurme gibi YETKI kararlari bu kapidan gecmez; onlar tenant status uzerinden
+// edge gateway ve authenticate katmanlarinda uygulanir.
+//
+// Fail-open sessiz olmamali. Her istekte log basmamak icin uyari kisilir.
+const FAIL_OPEN_LOG_INTERVAL_MS = 60 * 1000;
+let lastFailOpenLogAt = 0;
+
+function logFailOpen(reason) {
+  const now = Date.now();
+  if (now - lastFailOpenLogAt < FAIL_OPEN_LOG_INTERVAL_MS) {
+    return;
+  }
+  lastFailOpenLogAt = now;
+  console.warn(
+    `[RequestLimitGuard] fail-open: request quota gate could not be evaluated (reason=${reason}). ` +
+      'Monthly request limits are NOT enforced while this persists.'
+  );
+}
 
 function shouldSkipLimitGuard(request) {
   const url = request.url || '';
@@ -43,6 +65,20 @@ function getResetAt(periodKey) {
   return new Date(Date.UTC(year, month, 1, 0, 0, 0, 0)).toISOString();
 }
 
+/**
+ * Hot path kota kontrolu.
+ *
+ * Tek is yapar: tenant icin "kota asildi" bayragini Redis'ten okur (tek GET).
+ * Bayrak `apiUsageService.refreshMonthlyLimitFlag` tarafindan hot path DISINDA
+ * yazilir: zamanlanmis usage sync ve plan/odeme degisimi. Burada Mongo'ya
+ * gidilmez, kullanim yeniden hesaplanmaz, sayac dusurulmez.
+ *
+ * Sayim tarafi `middleware/apiLogger` icinde onResponse hook'unda, fire-and-forget
+ * olarak devam eder.
+ *
+ * Kabul edilen sapma: bayrak en fazla bir sync periyodu kadar geç yazilir, yani
+ * kotasi dolan bir tenant bir sonraki sync'e kadar servis almaya devam eder.
+ */
 async function checkRequestLimit(request, reply) {
   if (shouldSkipLimitGuard(request)) {
     return false;
@@ -53,37 +89,44 @@ async function checkRequestLimit(request, reply) {
     return false;
   }
 
-  try {
-    const state = await apiUsageService.reserveRequestQuota(tenantId, new Date());
-    request.requestQuotaState = state;
-
-    if (!state || state.skipped || state.allowed || state.isUnlimited) {
-      return false;
-    }
-
-    const messages = {
-      tr: 'Aylik API istegi limiti asildi. Lutfen paketinizi yukseltin veya yeni donemi bekleyin.',
-      en: 'Monthly API request limit exceeded. Please upgrade your plan or wait for the next billing cycle.',
-    };
-    const lang = resolveLanguage(request);
-
-    request.requestLimitExceeded = true;
-
-    reply.code(429).send({
-      error: 'RequestLimitExceeded',
-      message: messages[lang],
-      messages,
-      limit: state.limit ?? null,
-      usage: state.usage ?? null,
-      periodKey: state.periodKey ?? null,
-      resetAt: state.resetAt?.toISOString?.() || getResetAt(state.periodKey),
-    });
-
-    return true;
-  } catch (error) {
-    console.error('[RequestLimitGuard] Failed to evaluate request limit:', error.message);
+  if (!localRedisClient.isEnabled()) {
+    logFailOpen('redis_unavailable');
     return false;
   }
+
+  let flag = null;
+  try {
+    flag = await localRedisClient.getRequestLimitFlag(tenantId);
+  } catch (error) {
+    logFailOpen(`redis_error:${error.message}`);
+    return false;
+  }
+
+  // Only an explicit, valid exceeded flag may reject traffic. Missing or
+  // malformed state follows the documented metering fail-open policy.
+  if (flag?.exceeded !== true) {
+    return false;
+  }
+
+  const messages = {
+    tr: 'Aylik API istegi limiti asildi. Lutfen paketinizi yukseltin veya yeni donemi bekleyin.',
+    en: 'Monthly API request limit exceeded. Please upgrade your plan or wait for the next billing cycle.',
+  };
+  const lang = resolveLanguage(request);
+
+  request.requestLimitExceeded = true;
+
+  reply.code(429).send({
+    error: 'RequestLimitExceeded',
+    message: messages[lang],
+    messages,
+    limit: flag.limit ?? null,
+    usage: flag.usage ?? null,
+    periodKey: flag.periodKey ?? null,
+    resetAt: flag.resetAt || getResetAt(flag.periodKey),
+  });
+
+  return true;
 }
 
 module.exports = {

--- a/apps/api/src/middleware/requestLimitGuard.test.mjs
+++ b/apps/api/src/middleware/requestLimitGuard.test.mjs
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const localRedisClient = require('../lib/localRedis');
+const apiUsageService = require('../services/apiUsageService');
+const { checkRequestLimit, shouldSkipLimitGuard } = require('./requestLimitGuard');
+
+function createReply() {
+  const reply = {
+    statusCode: null,
+    payload: null,
+  };
+  reply.code = vi.fn((value) => {
+    reply.statusCode = value;
+    return reply;
+  });
+  reply.send = vi.fn((value) => {
+    reply.payload = value;
+    return reply;
+  });
+  return reply;
+}
+
+function createRequest(overrides = {}) {
+  return {
+    url: '/api/contents',
+    tenantId: 'tenant-1',
+    headers: {},
+    ...overrides,
+  };
+}
+
+describe('requestLimitGuard', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('skips guarded-exempt paths without touching Redis', async () => {
+    const getFlag = vi.spyOn(localRedisClient, 'getRequestLimitFlag');
+    const reply = createReply();
+
+    const blocked = await checkRequestLimit(createRequest({ url: '/health' }), reply);
+
+    expect(blocked).toBe(false);
+    expect(getFlag).not.toHaveBeenCalled();
+    expect(shouldSkipLimitGuard({ url: '/api/tenants/abc/limits' })).toBe(true);
+  });
+
+  it('passes through when there is no tenant on the request', async () => {
+    const getFlag = vi.spyOn(localRedisClient, 'getRequestLimitFlag');
+    const reply = createReply();
+
+    const blocked = await checkRequestLimit(createRequest({ tenantId: null }), reply);
+
+    expect(blocked).toBe(false);
+    expect(getFlag).not.toHaveBeenCalled();
+  });
+
+  it('reads the quota gate with a single Redis lookup and never recomputes usage', async () => {
+    vi.spyOn(localRedisClient, 'isEnabled').mockReturnValue(true);
+    const getFlag = vi.spyOn(localRedisClient, 'getRequestLimitFlag').mockResolvedValue(null);
+    const reserve = vi.spyOn(apiUsageService, 'reserveRequestQuota');
+    const monthlyUsage = vi.spyOn(apiUsageService, 'getMonthlyUsage');
+    const reply = createReply();
+
+    const blocked = await checkRequestLimit(createRequest(), reply);
+
+    expect(blocked).toBe(false);
+    expect(getFlag).toHaveBeenCalledTimes(1);
+    // Hot path must stay off Mongo: no quota reservation, no usage aggregation.
+    expect(reserve).not.toHaveBeenCalled();
+    expect(monthlyUsage).not.toHaveBeenCalled();
+    expect(reply.code).not.toHaveBeenCalled();
+  });
+
+  it('allows the request when the gate is explicitly not exceeded', async () => {
+    vi.spyOn(localRedisClient, 'isEnabled').mockReturnValue(true);
+    vi.spyOn(localRedisClient, 'getRequestLimitFlag').mockResolvedValue({
+      exceeded: false,
+      limit: 1000,
+      usage: 12,
+    });
+    const reply = createReply();
+
+    const blocked = await checkRequestLimit(createRequest(), reply);
+
+    expect(blocked).toBe(false);
+    expect(reply.code).not.toHaveBeenCalled();
+  });
+
+  it('fails open for malformed quota state', async () => {
+    vi.spyOn(localRedisClient, 'isEnabled').mockReturnValue(true);
+    vi.spyOn(localRedisClient, 'getRequestLimitFlag').mockResolvedValue({
+      limit: 1000,
+      usage: 1000,
+    });
+    const reply = createReply();
+
+    const blocked = await checkRequestLimit(createRequest(), reply);
+
+    expect(blocked).toBe(false);
+    expect(reply.code).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 with the gate payload when the quota is exceeded', async () => {
+    vi.spyOn(localRedisClient, 'isEnabled').mockReturnValue(true);
+    vi.spyOn(localRedisClient, 'getRequestLimitFlag').mockResolvedValue({
+      exceeded: true,
+      limit: 1000,
+      usage: 1000,
+      periodKey: '2026-08',
+      resetAt: '2026-09-01T00:00:00.000Z',
+    });
+    const reply = createReply();
+    const request = createRequest();
+
+    const blocked = await checkRequestLimit(request, reply);
+
+    expect(blocked).toBe(true);
+    expect(request.requestLimitExceeded).toBe(true);
+    expect(reply.statusCode).toBe(429);
+    expect(reply.payload).toMatchObject({
+      error: 'RequestLimitExceeded',
+      limit: 1000,
+      usage: 1000,
+      periodKey: '2026-08',
+      resetAt: '2026-09-01T00:00:00.000Z',
+    });
+  });
+
+  it('localises the 429 message from accept-language', async () => {
+    vi.spyOn(localRedisClient, 'isEnabled').mockReturnValue(true);
+    vi.spyOn(localRedisClient, 'getRequestLimitFlag').mockResolvedValue({
+      exceeded: true,
+      limit: 10,
+      usage: 10,
+      periodKey: '2026-08',
+    });
+    const reply = createReply();
+
+    await checkRequestLimit(createRequest({ headers: { 'accept-language': 'tr-TR,tr;q=0.9' } }), reply);
+
+    expect(reply.payload.message).toBe(reply.payload.messages.tr);
+  });
+
+  it('fails open and warns when Redis is unavailable', async () => {
+    vi.spyOn(localRedisClient, 'isEnabled').mockReturnValue(false);
+    const getFlag = vi.spyOn(localRedisClient, 'getRequestLimitFlag');
+    const reply = createReply();
+
+    const blocked = await checkRequestLimit(createRequest(), reply);
+
+    expect(blocked).toBe(false);
+    expect(getFlag).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('fail-open'));
+  });
+
+  it('fails open when the gate lookup throws', async () => {
+    vi.spyOn(localRedisClient, 'isEnabled').mockReturnValue(true);
+    vi.spyOn(localRedisClient, 'getRequestLimitFlag').mockRejectedValue(new Error('connection reset'));
+    const reply = createReply();
+
+    const blocked = await checkRequestLimit(createRequest(), reply);
+
+    expect(blocked).toBe(false);
+    expect(reply.code).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/subscriptionPlans.js
+++ b/apps/api/src/routes/subscriptionPlans.js
@@ -315,16 +315,11 @@ async function subscriptionPlanRoutes(fastify) {
 
       await tenant.save();
 
-      // Invalidate cache
-      const localRedisClient = require('../lib/localRedis');
-      await localRedisClient.invalidateTenantCache(tenantId);
-
-      // Refresh monthly request limit flag (limit may have changed)
-      try {
-        await apiUsageService.refreshMonthlyLimitFlag(tenantId);
-      } catch (error) {
-        console.warn('[Tenant] Failed to refresh limit flag:', error.message);
-      }
+      // Yetki degisimi tek noktadan yayilir: cache invalidation + kota bayragi
+      // + edge KV. Gecikmesiz olmali, bu yuzden senkron beklenir.
+      await tenantSubscriptionService.syncEntitlementState(tenantId, {
+        reason: 'subscription_updated',
+      });
 
       const plan = await tenantSubscriptionService.getPlanPayloadForTenant(tenant);
 

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -356,7 +356,54 @@ async function start() {
   });
 
   await localRedisClient.initialize();
-  
+
+  // Kota bayragini tazeleyen zamanlanmis is.
+  //
+  // Hot path artik kullanimi yeniden hesaplamiyor, sadece bu isin yazdigi
+  // bayragi okuyor. Dolayisiyla bu is calismazsa aylik istek limitleri hic
+  // uygulanmaz. Disaridaki cron'a (POST /api-usage-sync/trigger) bagimli
+  // kalmamak icin surec ici bir zamanlayici da tutuyoruz; ikisi ayni Redis
+  // kilidini (usage:sync:4hour) paylastigi icin pm2 cluster'da veya harici
+  // cron ile birlikte cakismaz.
+  //
+  // Bu araligin uzunlugu, kotasi dolan bir tenant'in ne kadar sure fazladan
+  // servis alabilecegini belirler. 0 verilirse surec ici zamanlayici kapanir
+  // (yalniz harici cron kullanilir).
+  const usageSyncIntervalMinutes = Number.parseInt(
+    process.env.USAGE_SYNC_INTERVAL_MINUTES ?? '60',
+    10
+  );
+
+  if (Number.isFinite(usageSyncIntervalMinutes) && usageSyncIntervalMinutes > 0) {
+    const intervalMs = usageSyncIntervalMinutes * 60 * 1000;
+    const apiUsageSyncService = require('./services/apiUsageSyncService');
+    let usageSyncRunning = false;
+
+    const timer = setInterval(() => {
+      if (usageSyncRunning) {
+        return;
+      }
+      usageSyncRunning = true;
+      apiUsageSyncService
+        .runScheduledSync({ includeCurrent: true })
+        .catch((error) => {
+          console.error('[Server] Scheduled usage sync failed:', error.message);
+        })
+        .finally(() => {
+          usageSyncRunning = false;
+        });
+    }, intervalMs);
+
+    timer.unref();
+    console.log(`[Server] Usage quota gate refresh scheduled every ${usageSyncIntervalMinutes}m`);
+  } else {
+    console.warn(
+      '[Server] In-process usage sync disabled (USAGE_SYNC_INTERVAL_MINUTES=0). ' +
+        'Request limits will only be enforced if an external cron calls POST /api-usage-sync/trigger.'
+    );
+  }
+
+
   const app = await buildServer();
   const port = process.env.PORT || 3000;
   const host = process.env.HOST || '0.0.0.0';

--- a/apps/api/src/services/apiUsageService.js
+++ b/apps/api/src/services/apiUsageService.js
@@ -351,6 +351,18 @@ async function refreshMonthlyLimitFlag(tenantId, date = new Date(), options = {}
   return state;
 }
 
+/**
+ * @deprecated Hot path'te KULLANMAYIN.
+ *
+ * Bu fonksiyon istek basina 3 Mongo sorgusu (tenant + plan + ApiUsage aggregate)
+ * ve fatura dongusu boyunca periyot basina bir Redis okumasi (~180) yapar.
+ * `requestLimitGuard` artik bunun yerine `localRedis.getRequestLimitFlag` ile
+ * tek bir GET yapiyor; bayrak `refreshMonthlyLimitFlag` tarafindan hot path
+ * disinda yaziliyor.
+ *
+ * Geriye donuk uyumluluk icin export edilmeye devam ediyor. Yeni bir cagri
+ * eklemeden once neden hot path'te olmadigindan emin olun.
+ */
 async function reserveRequestQuota(tenantId, date = new Date()) {
   const initialState = await resolveRequestLimitState(tenantId, date);
   if (initialState.skipped) {

--- a/apps/api/src/services/tenantSubscriptionService.js
+++ b/apps/api/src/services/tenantSubscriptionService.js
@@ -228,6 +228,63 @@ class TenantSubscriptionService {
     return next;
   }
 
+  /**
+   * Yetki (entitlement) degisimini calisan sisteme yayar.
+   *
+   * Plan degisimi, ozel limit guncellemesi ve ileride eklenecek odeme
+   * webhook'lari bu tek noktadan gecmelidir. Kullanim sayaci gecikmeli
+   * calisabilir, ama YETKI gecikmeli olamaz: musteri paketini yukselttiginde
+   * bir sonraki istegi acik olmali, dusurdugunde/odemesi basarisiz oldugunda
+   * gecikmeden kisitlanmalidir.
+   *
+   * Tenant `save()` edildikten SONRA cagrilmalidir; kaynak dogruluk Mongo'dur.
+   *
+   * Yapilan is:
+   *  1. tenant limit cache'ini dusur (Redis)
+   *  2. aylik istek kota bayragini yeniden hesaplayip yaz (hot path bunu okur)
+   *  3. tenant config'ini edge KV'ye it (edge gateway kapaliysa no-op)
+   */
+  async syncEntitlementState(tenantId, { reason = 'entitlement_change' } = {}) {
+    if (!tenantId) {
+      throw new Error('tenantId is required');
+    }
+
+    const id = String(tenantId);
+    const result = { tenantId: id, reason, cacheInvalidated: false, limitFlag: null, edge: null };
+
+    // Dongusel import olmamasi icin lazy require.
+    const localRedisClient = require('../lib/localRedis');
+    const apiUsageService = require('./apiUsageService');
+    const edgeGatewaySyncService = require('./edgeGatewaySyncService');
+
+    try {
+      result.cacheInvalidated = await localRedisClient.invalidateTenantCache(id);
+    } catch (error) {
+      console.warn(`[TenantSubscription] Failed to invalidate tenant cache (${id}):`, error.message);
+    }
+
+    try {
+      const state = await apiUsageService.refreshMonthlyLimitFlag(id);
+      result.limitFlag = {
+        limit: state?.limit ?? null,
+        usage: state?.usage ?? null,
+        exceeded: state?.exceeded ?? false,
+        periodKey: state?.periodKey ?? null,
+      };
+    } catch (error) {
+      console.error(`[TenantSubscription] Failed to refresh request limit flag (${id}):`, error.message);
+    }
+
+    try {
+      result.edge = await edgeGatewaySyncService.syncTenantConfig({ tenantId: id });
+    } catch (error) {
+      console.error(`[TenantSubscription] Failed to sync tenant config to edge KV (${id}):`, error.message);
+      result.edge = { skipped: true, reason: 'edge_sync_failed', error: error.message };
+    }
+
+    return result;
+  }
+
   applyCustomLimits(tenant, customLimits = {}) {
     if (!tenant) {
       throw new Error('Tenant is required');

--- a/apps/api/src/services/tenantSubscriptionService.test.mjs
+++ b/apps/api/src/services/tenantSubscriptionService.test.mjs
@@ -120,4 +120,61 @@ describe('tenantSubscriptionService', () => {
       monthlyRequestLimit: -1,
     });
   });
+
+  describe('syncEntitlementState', () => {
+    const localRedisClient = require('../lib/localRedis');
+    const apiUsageService = require('./apiUsageService');
+    const edgeGatewaySyncService = require('./edgeGatewaySyncService');
+
+    it('propagates an entitlement change to cache, quota gate and edge KV', async () => {
+      const invalidate = vi.spyOn(localRedisClient, 'invalidateTenantCache').mockResolvedValue(true);
+      const refresh = vi.spyOn(apiUsageService, 'refreshMonthlyLimitFlag').mockResolvedValue({
+        limit: 5000,
+        usage: 120,
+        exceeded: false,
+        periodKey: '2026-08',
+      });
+      const edgeSync = vi
+        .spyOn(edgeGatewaySyncService, 'syncTenantConfig')
+        .mockResolvedValue({ skipped: false, key: 'tenant:t1' });
+
+      const result = await tenantSubscriptionService.syncEntitlementState('t1', {
+        reason: 'subscription_updated',
+      });
+
+      expect(invalidate).toHaveBeenCalledWith('t1');
+      expect(refresh).toHaveBeenCalledWith('t1');
+      expect(edgeSync).toHaveBeenCalledWith({ tenantId: 't1' });
+      expect(result).toMatchObject({
+        tenantId: 't1',
+        reason: 'subscription_updated',
+        cacheInvalidated: true,
+        limitFlag: { limit: 5000, usage: 120, exceeded: false, periodKey: '2026-08' },
+      });
+    });
+
+    it('still writes the quota gate when edge KV sync fails', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(localRedisClient, 'invalidateTenantCache').mockResolvedValue(true);
+      const refresh = vi.spyOn(apiUsageService, 'refreshMonthlyLimitFlag').mockResolvedValue({
+        limit: 100,
+        usage: 100,
+        exceeded: true,
+        periodKey: '2026-08',
+      });
+      vi.spyOn(edgeGatewaySyncService, 'syncTenantConfig').mockRejectedValue(new Error('KV down'));
+
+      const result = await tenantSubscriptionService.syncEntitlementState('t2');
+
+      expect(refresh).toHaveBeenCalledWith('t2');
+      expect(result.limitFlag.exceeded).toBe(true);
+      expect(result.edge).toMatchObject({ skipped: true, reason: 'edge_sync_failed' });
+    });
+
+    it('requires a tenantId', async () => {
+      await expect(tenantSubscriptionService.syncEntitlementState(null)).rejects.toThrow(
+        'tenantId is required'
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- replace per-request Mongo quota recomputation with a single Redis exceeded-flag read
- refresh the flag outside the hot path through scheduled usage sync and entitlement changes
- propagate subscription entitlement changes to Redis cache, quota state, and Edge KV
- fail open explicitly when the metering gate is unavailable; only an explicit `exceeded: true` blocks traffic
- preserve Redis read failures so the guard's throttled fail-open warning works without per-request log spam

## Operational behavior
- `USAGE_SYNC_INTERVAL_MINUTES=60` by default
- PM2 workers share the existing Redis sync lock
- Redis outage does not become a global API outage; quota enforcement warns and fails open

## Verification
- API tests: 24 files / 129 tests passed
- API lint passed
- rebased on current production `main`, including N1 origin protection