### PR TITLE
Fix paid-plan entitlement payloads

### DIFF
--- a/apps/api/src/lib/extensionEntitlementFacade.js
+++ b/apps/api/src/lib/extensionEntitlementFacade.js
@@ -22,7 +22,10 @@ function normalizeRequiredFeatures(features) {
 function createExtensionEntitlementFacade(manifest, options = {}) {
   const declaredFeatures = new Set(manifest.featureKeys);
   const loadTenantFeatures = options.loadTenantFeatures || (async (tenantId) => {
-    const tenant = await Tenant.findById(tenantId).select('plan currentPlan').lean();
+    const tenant = await Tenant.findById(tenantId)
+      .select('plan currentPlan')
+      .populate('currentPlan')
+      .lean();
     if (!tenant) return [];
     const plan = await tenantSubscriptionService.getPlanPayloadForTenant(tenant);
     return plan.features || [];

--- a/apps/api/src/lib/extensionEntitlementFacade.test.js
+++ b/apps/api/src/lib/extensionEntitlementFacade.test.js
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'module';
 import entitlementModule from './extensionEntitlementFacade';
+
+const require = createRequire(import.meta.url);
+const { Tenant } = require('@contexthub/common');
 
 const {
   ExtensionEntitlementFacadeError,
@@ -12,6 +16,30 @@ const manifest = {
 };
 
 describe('extension entitlement facade', () => {
+  it('uses the referenced paid plan when the legacy plan string is stale', async () => {
+    const query = {
+      select: vi.fn().mockReturnThis(),
+      populate: vi.fn().mockReturnThis(),
+      lean: vi.fn().mockResolvedValue({
+        plan: 'free',
+        currentPlan: {
+          slug: 'enterprise',
+          features: ['search.semantic', 'content.related'],
+        },
+      }),
+    };
+    vi.spyOn(Tenant, 'findById').mockReturnValue(query);
+    const facade = createExtensionEntitlementFacade(manifest);
+
+    await expect(facade.has(
+      { tenantId: 'tenant-1' },
+      ['search.semantic', 'content.related']
+    )).resolves.toBe(true);
+
+    expect(query.select).toHaveBeenCalledWith('plan currentPlan');
+    expect(query.populate).toHaveBeenCalledWith('currentPlan');
+  });
+
   it('allows an entitled tenant and denies a missing feature', async () => {
     const facade = createExtensionEntitlementFacade(manifest, {
       loadTenantFeatures: async () => ['search.semantic'],

--- a/apps/api/src/scripts/backfillTenantSubscriptions.js
+++ b/apps/api/src/scripts/backfillTenantSubscriptions.js
@@ -35,6 +35,10 @@ function parseArgs(argv = []) {
   };
 }
 
+function resolveTargetPlanSlug(tenant, requestedPlanSlug = null) {
+  return requestedPlanSlug || tenant?.currentPlan?.slug || tenant?.plan || 'free';
+}
+
 async function backfillTenantSubscriptions(options = {}) {
   const args = {
     ...parseArgs(process.argv.slice(2)),
@@ -53,7 +57,9 @@ async function backfillTenantSubscriptions(options = {}) {
       throw new Error(`Tenant not found for slug: ${args.tenantSlug}`);
     }
 
-    const targetPlanSlug = args.planSlug || tenant.plan || tenant.currentPlan?.slug || 'free';
+    // currentPlan is the canonical reference. Prefer it over the legacy mirrored
+    // string so a stale `plan=free` value cannot downgrade a paid tenant.
+    const targetPlanSlug = resolveTargetPlanSlug(tenant, args.planSlug);
     const planResult = await tenantSubscriptionService.applyPlanToTenant(tenant, targetPlanSlug);
 
     let limitsChanged = false;
@@ -68,6 +74,9 @@ async function backfillTenantSubscriptions(options = {}) {
 
     if (changed && !args.dryRun) {
       await tenant.save();
+      await tenantSubscriptionService.syncEntitlementState(tenant._id, {
+        reason: 'subscription_backfill',
+      });
     }
 
     const summary = {
@@ -100,3 +109,4 @@ if (require.main === module) {
 }
 
 module.exports = backfillTenantSubscriptions;
+module.exports.resolveTargetPlanSlug = resolveTargetPlanSlug;

--- a/apps/api/src/scripts/backfillTenantSubscriptions.test.mjs
+++ b/apps/api/src/scripts/backfillTenantSubscriptions.test.mjs
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { resolveTargetPlanSlug } = require('./backfillTenantSubscriptions');
+
+describe('backfillTenantSubscriptions plan resolution', () => {
+  it('prefers an explicit plan over stored tenant state', () => {
+    expect(resolveTargetPlanSlug({
+      plan: 'free',
+      currentPlan: { slug: 'enterprise' },
+    }, 'pro')).toBe('pro');
+  });
+
+  it('prefers the canonical currentPlan over a stale legacy plan string', () => {
+    expect(resolveTargetPlanSlug({
+      plan: 'free',
+      currentPlan: { slug: 'enterprise' },
+    })).toBe('enterprise');
+  });
+
+  it('falls back to the legacy plan when no reference exists', () => {
+    expect(resolveTargetPlanSlug({ plan: 'promax', currentPlan: null })).toBe('promax');
+  });
+});

--- a/apps/api/src/services/authService.entitlements.test.mjs
+++ b/apps/api/src/services/authService.entitlements.test.mjs
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { Membership, User } = require('@contexthub/common');
+const AuthService = require('./authService');
+const roleService = require('./roleService');
+
+describe('AuthService entitlement memberships', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns normalized features from currentPlan when the legacy plan string is stale', async () => {
+    const enterprisePlan = {
+      _id: 'plan-enterprise',
+      slug: 'enterprise',
+      name: 'Enterprise',
+      features: ['search.semantic', 'content.related'],
+    };
+    const tenant = {
+      _id: { toString: () => 'tenant-1' },
+      name: 'Legacy Enterprise Tenant',
+      slug: 'legacy-enterprise',
+      plan: 'free',
+      currentPlan: enterprisePlan,
+      status: 'active',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const membership = {
+      _id: { toString: () => 'membership-1' },
+      tenantId: tenant,
+      role: 'owner',
+      status: 'active',
+    };
+    const membershipQuery = {
+      populate: vi.fn().mockResolvedValue([membership]),
+    };
+    vi.spyOn(Membership, 'find').mockReturnValue(membershipQuery);
+    vi.spyOn(User, 'findById').mockReturnValue({
+      select: vi.fn().mockResolvedValue({
+        _id: { toString: () => 'user-1' },
+        email: 'owner@example.test',
+        firstName: 'Owner',
+        lastName: 'User',
+        status: 'active',
+      }),
+    });
+    vi.spyOn(roleService, 'ensureRoleReference').mockResolvedValue({
+      role: { _id: 'role-owner', key: 'owner', name: 'Owner' },
+      permissions: ['semanticSearch.query'],
+    });
+    vi.spyOn(roleService, 'formatRole').mockReturnValue({ id: 'role-owner', key: 'owner' });
+
+    const state = await new AuthService({}).getSessionState('user-1', { tenantId: 'tenant-1' });
+
+    expect(membershipQuery.populate).toHaveBeenCalledWith(expect.objectContaining({
+      path: 'tenantId',
+      select: expect.stringContaining('currentPlan'),
+      populate: { path: 'currentPlan' },
+    }));
+    expect(state.activeMembership.tenant).toMatchObject({
+      plan: 'enterprise',
+      planName: 'Enterprise',
+      currentPlan: expect.objectContaining({ slug: 'enterprise' }),
+      features: ['search.semantic', 'content.related'],
+    });
+  });
+});

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -65,7 +65,11 @@ async function getActiveMembershipDetails(userId) {
   const memberships = await Membership.find({
     userId,
     status: 'active'
-  }).populate('tenantId', 'name slug plan status createdAt');
+  }).populate({
+    path: 'tenantId',
+    select: 'name slug plan currentPlan status createdAt',
+    populate: { path: 'currentPlan' }
+  });
 
   return Promise.all(
     memberships.map(async (membershipDoc) => {
@@ -88,8 +92,9 @@ async function getActiveMembershipDetails(userId) {
               id: tenant._id.toString(),
               name: tenant.name,
               slug: tenant.slug,
-              plan: tenant.plan,
+              plan: plan?.slug || tenant.plan,
               planName: plan?.name || tenant.plan,
+              currentPlan: plan,
               features: plan?.features || [],
               status: tenant.status,
               createdAt: tenant.createdAt,

--- a/apps/api/src/services/tenantService.entitlements.test.mjs
+++ b/apps/api/src/services/tenantService.entitlements.test.mjs
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { Membership } = require('@contexthub/common');
+const tenantService = require('./tenantService');
+const roleService = require('./roleService');
+
+describe('TenantService entitlement summaries', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preserves normalized plan features when memberships refresh in Admin', async () => {
+    const tenant = {
+      _id: { toString: () => 'tenant-1' },
+      name: 'Enterprise Tenant',
+      slug: 'enterprise-tenant',
+      plan: 'free',
+      currentPlan: {
+        _id: 'plan-enterprise',
+        slug: 'enterprise',
+        name: 'Enterprise',
+        features: ['search.semantic', 'content.related'],
+      },
+      status: 'active',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const membership = {
+      _id: { toString: () => 'membership-1' },
+      tenantId: tenant,
+      role: 'owner',
+      status: 'active',
+    };
+    const query = {
+      populate: vi.fn().mockReturnThis(),
+      sort: vi.fn().mockResolvedValue([membership]),
+    };
+    vi.spyOn(Membership, 'find').mockReturnValue(query);
+    vi.spyOn(Membership, 'countDocuments').mockResolvedValue(1);
+    vi.spyOn(roleService, 'ensureRoleReference').mockResolvedValue({
+      role: { _id: 'role-owner', key: 'owner', name: 'Owner' },
+      permissions: ['semanticSearch.query'],
+    });
+    vi.spyOn(roleService, 'formatRole').mockReturnValue({ id: 'role-owner', key: 'owner' });
+
+    const memberships = await tenantService.listUserTenants('user-1');
+
+    expect(memberships[0].tenant).toMatchObject({
+      plan: 'enterprise',
+      planName: 'Enterprise',
+      currentPlan: expect.objectContaining({ slug: 'enterprise' }),
+      features: ['search.semantic', 'content.related'],
+    });
+  });
+});

--- a/apps/api/src/services/tenantService.js
+++ b/apps/api/src/services/tenantService.js
@@ -24,6 +24,7 @@ class TenantService {
       plan: plan.slug,
       planName: plan.name,
       currentPlan: plan,
+      features: plan.features || [],
       status: tenantDoc.status,
       createdAt: tenantDoc.createdAt
     };


### PR DESCRIPTION
## What changed
- Normalize auth and tenant-list plan/feature payloads from the referenced `currentPlan`
- Make the plugin entitlement facade populate and honor referenced paid plans
- Harden subscription recovery so `currentPlan` wins over stale legacy plan strings and entitlement state is synchronized
- Add regressions for stale legacy `tenant.plan` values

## Root cause
Legacy paid tenants could retain `tenant.plan=free` while `currentPlan` referenced Enterprise. Admin displayed Enterprise from one endpoint, while auth and API entitlement checks evaluated the stale Free value.

## Impact
Free remains excluded. Pro, Pro Max and Enterprise receive their plan-defined commercial feature keys consistently. No commercial feature key is hardcoded into the public core.

## Live data repair
KESKORGTR and MEDNRORG legacy plan mirrors were aligned with their Enterprise references. A read-only audit of all 9 tenants with `currentPlan` now reports zero mismatches. KESK's Semantic Search allow-list screen was verified unlocked in an authenticated live session.

## Validation
- `pnpm version:check`
- `pnpm lint`
- `pnpm test` (API: 33 files, 152 tests; full monorepo passed)
- `pnpm build`
