### PR TITLE
fix(consumers): dead-letter permanent failures immediately

### DIFF
--- a/apps/api/src/lib/domainEventConsumerRunner.js
+++ b/apps/api/src/lib/domainEventConsumerRunner.js
@@ -162,7 +162,10 @@ function createDomainEventConsumerRunner(options = {}) {
         handled += 1;
       } catch (error) {
         const normalizedError = serializeError(error);
-        if (attempt < registration.maxAttempts) {
+        const shouldRetry =
+          normalizedError.retryable !== false &&
+          attempt < registration.maxAttempts;
+        if (shouldRetry) {
           const delayMs = calculateRetryDelay(registration.retry, attempt);
           const nextAttemptAt = new Date(now().getTime() + delayMs);
           await store.scheduleRetry({
@@ -209,6 +212,7 @@ function createDomainEventConsumerRunner(options = {}) {
           eventId: event.id,
           eventSequence: event.sequence,
           attempt,
+          retryable: normalizedError.retryable,
           handledBeforeFailure: handled
         };
       }

--- a/apps/api/src/lib/domainEventConsumerRunner.test.js
+++ b/apps/api/src/lib/domainEventConsumerRunner.test.js
@@ -157,6 +157,45 @@ describe('domain event consumer runner', () => {
     expect(handle).toHaveBeenCalledOnce()
   })
 
+  it('dead-letters a permanent error on the first attempt without scheduling retry', async () => {
+    const error = Object.assign(new Error('queue payload is too large'), {
+      code: 'QUEUE_MESSAGE_TOO_LARGE',
+      retryable: false
+    })
+    const handle = vi.fn().mockRejectedValue(error)
+    const context = setup({ handle, maxAttempts: 8 })
+    context.store.readEvents.mockResolvedValue([event(7), event(8)])
+
+    await expect(
+      context.runner.runPartition('test-consumer', 'tenant-a')
+    ).resolves.toMatchObject({
+      status: 'dead-lettered',
+      eventSequence: 7,
+      attempt: 1,
+      retryable: false
+    })
+    expect(context.store.scheduleRetry).not.toHaveBeenCalled()
+    expect(context.store.persistDeadLetter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({ sequence: 7 }),
+        attempt: 1,
+        error: expect.objectContaining({
+          code: 'QUEUE_MESSAGE_TOO_LARGE',
+          retryable: false
+        })
+      })
+    )
+    expect(context.store.advanceCursor).toHaveBeenCalledWith(
+      context.storedCursor,
+      'runner-1',
+      0,
+      7
+    )
+    expect(
+      context.store.persistDeadLetter.mock.invocationCallOrder[0]
+    ).toBeLessThan(context.store.advanceCursor.mock.invocationCallOrder[0])
+  })
+
   it('recovers a DLQ-first crash without invoking the handler again', async () => {
     const context = setup()
     context.store.readEvents.mockResolvedValue([event(4)])


### PR DESCRIPTION
## Özet
- F2 consumer runner artık handler tarafından `retryable: false` olarak sınıflandırılan kalıcı hataları ilk denemede DLQ'ya alır.
- DLQ kaydı cursor ilerlemesinden önce kalıcılaştırılır.
- Retryable ve sınıflandırılmamış hataların mevcut exponential-backoff / maxAttempts davranışı korunur.

## Neden
Queue payload sınırı gibi kalıcı transport hataları sekiz kez yeniden denenerek tenant partition'ını gereksiz yere bekletiyordu.

## Test
- `pnpm --filter @contexthub/api test` — 153/153
- `pnpm --filter @contexthub/api lint`
- `pnpm identity:check`
- `pnpm version:check`