### PR TITLE
Harden tenant, login, rate limit, and webhook security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,16 @@ R2_BUCKET=my-bucket
 REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
 
+# Server-wide volumetric guard (per trusted Cloudflare client IP). Login has a
+# separate, stricter route limit and failed credentials are also tracked in
+# independent per-email and per-IP one-hour buckets.
+API_RATE_LIMIT_MAX=1000
+API_RATE_LIMIT_WINDOW_MS=60000
+AUTH_LOGIN_RATE_LIMIT_MAX=10
+AUTH_LOGIN_RATE_LIMIT_WINDOW_MS=60000
+LOGIN_EMAIL_MAX_ATTEMPTS=5
+LOGIN_IP_MAX_ATTEMPTS=20
+
 # Kota bayragini tazeleyen zamanlanmis isin araligi (dakika).
 # Hot path kullanimi yeniden hesaplamaz, sadece bu isin yazdigi bayragi okur;
 # bu deger kotasi dolan bir tenant'in en fazla ne kadar fazladan servis
@@ -90,6 +100,10 @@ DOMAIN_EVENT_BATCH_LIMIT=100
 WEBHOOK_MAX_RETRY_ATTEMPTS=5
 WEBHOOK_RETRY_BACKOFF_MS=60000
 WEBHOOK_FAILED_CLEANUP_MS=604800000 # 7 days
+# Private/reserved webhook targets are blocked by default. For an intentional
+# local-only development receiver, opt in explicitly; this flag is ignored in
+# production.
+WEBHOOK_ALLOW_PRIVATE_TARGETS=false
 SCHEDULED_PUBLISH_LIMIT=50
 
 # Optional extension manifests. Prefer a JSON array of absolute paths in composed

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -33,6 +33,7 @@
     "@contexthub/common": "workspace:*",
     "@fastify/cors": "^8.5.0",
     "@fastify/jwt": "^7.2.4",
+    "@fastify/rate-limit": "^9.1.0",
     "@fastify/swagger": "^8.15.0",
     "@fastify/swagger-ui": "^4.2.0",
     "bcryptjs": "^2.4.3",

--- a/apps/api/src/lib/webhookDispatcher.js
+++ b/apps/api/src/lib/webhookDispatcher.js
@@ -1,6 +1,10 @@
 const crypto = require('node:crypto');
 const { fetch } = require('undici');
 const { mongoose } = require('@contexthub/common');
+const {
+  closeWebhookDispatcher,
+  prepareSafeWebhookRequest
+} = require('../services/webhookUrlSecurity');
 
 const DEFAULT_BATCH_LIMIT = 50;
 const MAX_LOG_BODY_LENGTH = 500;
@@ -31,6 +35,9 @@ const ERROR_TYPES = {
  * @returns {string} ERROR_TYPES değerlerinden biri
  */
 function classifyError(statusCode, error) {
+  if (error?.code === 'WEBHOOK_URL_BLOCKED') {
+    return ERROR_TYPES.PERMANENT;
+  }
   // Timeout hatası
   if (error?.name === 'TimeoutError' || error?.code === 'UND_ERR_CONNECT_TIMEOUT' || error?.message?.includes('timeout')) {
     return ERROR_TYPES.TIMEOUT;
@@ -254,24 +261,32 @@ async function dispatchWebhookOutboxBatch(options = {}) {
         ? performance.now()
         : Date.now();
 
-      const response = await fetch(webhook.url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CTXHUB-SIGNATURE': signature,
-          'X-CTXHUB-EVENT': job.type
-        },
-        body,
-        signal: resolveAbortSignal(options.timeoutMs || 15000)
-      });
+      const prepared = await prepareSafeWebhookRequest(webhook.url);
+      let response;
+      try {
+        response = await fetch(prepared.url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CTXHUB-SIGNATURE': signature,
+            'X-CTXHUB-EVENT': job.type
+          },
+          body,
+          redirect: 'error',
+          dispatcher: prepared.dispatcher,
+          signal: resolveAbortSignal(options.timeoutMs || 15000)
+        });
 
-      responseStatus = response.status;
-      const endTime = typeof performance !== 'undefined' && performance.now
-        ? performance.now()
-        : Date.now();
-      durationMs = Math.round(endTime - startTime);
+        responseStatus = response.status;
+        const endTime = typeof performance !== 'undefined' && performance.now
+          ? performance.now()
+          : Date.now();
+        durationMs = Math.round(endTime - startTime);
 
-      responseBodySnippet = await readResponseSnippet(response);
+        responseBodySnippet = await readResponseSnippet(response);
+      } finally {
+        await closeWebhookDispatcher(prepared.dispatcher);
+      }
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);

--- a/apps/api/src/routes/auth.js
+++ b/apps/api/src/routes/auth.js
@@ -8,9 +8,29 @@ const {
 
 async function authRoutes(fastify) {
   const authService = new AuthService(fastify);
+  const configuredLoginRateLimitMax = Number.parseInt(
+    process.env.AUTH_LOGIN_RATE_LIMIT_MAX || '',
+    10
+  );
+  const configuredLoginRateLimitWindowMs = Number.parseInt(
+    process.env.AUTH_LOGIN_RATE_LIMIT_WINDOW_MS || '',
+    10
+  );
+  const loginRateLimitMax = configuredLoginRateLimitMax > 0
+    ? configuredLoginRateLimitMax
+    : 10;
+  const loginRateLimitWindowMs = configuredLoginRateLimitWindowMs > 0
+    ? configuredLoginRateLimitWindowMs
+    : 60 * 1000;
 
   // POST /auth/login - Giriş yap
   fastify.post('/auth/login', {
+    config: {
+      rateLimit: {
+        max: loginRateLimitMax,
+        timeWindow: loginRateLimitWindowMs,
+      },
+    },
     schema: {
       description: 'Authenticate user with email and password',
       summary: 'User login',

--- a/apps/api/src/routes/publicCollections.js
+++ b/apps/api/src/routes/publicCollections.js
@@ -11,6 +11,7 @@ const {
 const {
   getCollectionType
 } = require('../services/collectionTypeService');
+const { extractTrustedClientIp } = require('../services/clientIp');
 const {
   entryListQuerySchema,
   collectionQuerySchema
@@ -357,7 +358,7 @@ async function publicCollectionRoutes(fastify) {
     }
   }, async (request, reply) => {
     try {
-      enforceRateLimit(request.tenantId, request.ip || request.headers['x-forwarded-for'] || 'unknown');
+      enforceRateLimit(request.tenantId, extractTrustedClientIp(request));
     } catch (error) {
       request.log.warn({ err: error }, 'Public query rate limit exceeded');
       return reply

--- a/apps/api/src/routes/publicForms.js
+++ b/apps/api/src/routes/publicForms.js
@@ -3,6 +3,7 @@ const { checkRequestLimit } = require('../middleware/requestLimitGuard');
 const formService = require('../services/formService');
 const localRedisClient = require('../lib/localRedis');
 const crypto = require('crypto');
+const { extractTrustedClientIp } = require('../services/clientIp');
 
 /**
  * Rate limiting configuration for form submissions
@@ -660,7 +661,7 @@ async function publicFormRoutes(fastify) {
       if (reply.sent) return;
 
       // Extract client identification signals
-      const ip = request.ip || request.headers['x-forwarded-for'] || 'unknown';
+      const ip = extractTrustedClientIp(request);
       const userAgent = request.headers['user-agent'] || '';
       const acceptLanguage = request.headers['accept-language'] || '';
 

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -3,6 +3,7 @@ const fp = require('fastify-plugin');
 const crypto = require('crypto');
 const jwt = require('@fastify/jwt');
 const cors = require('@fastify/cors');
+const rateLimit = require('@fastify/rate-limit');
 const swagger = require('@fastify/swagger');
 const swaggerUi = require('@fastify/swagger-ui');
 const dotenv = require('dotenv');
@@ -16,6 +17,7 @@ const localRedisClient = require('./lib/localRedis');
 const { getSessionCookieName } = require('./services/sessionSecurity');
 const { resolveCorsOptions } = require('./services/tenantOriginPolicy');
 const { bootstrapExtensions } = require('./lib/pluginHost');
+const { extractTrustedClientIp } = require('./services/clientIp');
 
 // Load environment variables from a local .env file when present.  Production deployments should use secrets management instead.
 dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
@@ -37,6 +39,11 @@ function envList(name, defaultValue = '') {
     .split(',')
     .map(item => item.trim())
     .filter(Boolean);
+}
+
+function positiveIntegerEnv(name, defaultValue) {
+  const parsed = Number.parseInt(process.env[name] || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
 }
 
 // Minimum acceptable JWT secret length in bytes (256-bit).  Anything shorter is
@@ -89,7 +96,9 @@ async function buildServer(options = {}) {
   // on the first login request.
   getSessionCookieName();
 
-  // trustProxy true ensures request.ip reflects real client IP when behind Nginx/ELB
+  // Some non-security logging still uses Fastify's proxy-aware request.ip. Security
+  // controls use extractTrustedClientIp so a forged left-most X-Forwarded-For value
+  // cannot select the limiter key.
   const bodyLimit = Number(process.env.API_BODY_LIMIT_BYTES) || 10 * 1024 * 1024;
   // Fastify's default maxParamLength is 100; long slugs (e.g. migrated `id-detail`
   // slugs) exceed it and make the router 404 on /contents/slug/:slug. Raise the ceiling
@@ -112,6 +121,20 @@ async function buildServer(options = {}) {
       reply.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
     }
     return payload;
+  });
+
+  await app.register(rateLimit, {
+    global: true,
+    max: positiveIntegerEnv('API_RATE_LIMIT_MAX', 1000),
+    timeWindow: positiveIntegerEnv('API_RATE_LIMIT_WINDOW_MS', 60 * 1000),
+    keyGenerator: extractTrustedClientIp,
+    allowList: (request) => request.raw.url === '/health' || request.raw.url === '/ready',
+    errorResponseBuilder: (_request, context) => ({
+      statusCode: 429,
+      error: 'RateLimitExceeded',
+      message: 'Too many requests. Please retry later.',
+      retryAfter: context.after,
+    }),
   });
 
   // Register Swagger for OpenAPI documentation

--- a/apps/api/src/server.test.mjs
+++ b/apps/api/src/server.test.mjs
@@ -10,6 +10,8 @@ const TEST_R2_ENV = {
   R2_S3_ENDPOINT: 'https://r2.example.test',
   R2_ACCESS_KEY: 'test-access-key',
   R2_SECRET_KEY: 'test-secret-key',
+  AUTH_LOGIN_RATE_LIMIT_MAX: '3',
+  AUTH_LOGIN_RATE_LIMIT_WINDOW_MS: '60000',
 };
 const originalR2Env = new Map(
   Object.keys(TEST_R2_ENV).map((key) => [key, process.env[key]])
@@ -123,5 +125,24 @@ describe('API server', () => {
     expect(res.headers['set-cookie']).toContain('ctx_session=mock-token');
     expect(res.headers['set-cookie']).toContain('HttpOnly');
     expect(res.headers['set-cookie']).toContain('SameSite=Strict');
+  });
+
+  it('throttles repeated login requests independently from the global API limit', async () => {
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { email: 'invalid@example.com', password: 'wrong' },
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { email: 'invalid@example.com', password: 'wrong' },
+    });
+
+    expect(first.statusCode).toBe(401);
+    expect(second.statusCode).toBe(429);
+    expect(JSON.parse(second.payload)).toMatchObject({
+      error: 'RateLimitExceeded',
+    });
   });
 });

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -10,6 +10,7 @@ const loginRateLimiter = require('./loginRateLimiter');
 const tokenBlacklist = require('./tokenBlacklist');
 const { issueSessionToken } = require('./sessionSecurity');
 const { hashIdentifier, logSecurityEvent } = require('./auditService');
+const { extractTrustedClientIp } = require('./clientIp');
 
 // Session token lifetime and absolute session cap. A JWT lives for TOKEN_TTL and can
 // be refreshed, but refresh cannot keep a session alive past MAX_SESSION_AGE_SECONDS
@@ -25,41 +26,6 @@ function nowInSeconds() {
 // comparison when the email is unknown, so login response timing does not reveal
 // whether an account exists (account-enumeration defense).
 const DUMMY_PASSWORD_HASH = bcrypt.hashSync('contexthub-nonexistent-account-placeholder', 12);
-
-function extractClientIp(request) {
-  // Fastify will populate request.ips when trustProxy is enabled
-  if (Array.isArray(request?.ips) && request.ips.length) {
-    const candidate = request.ips.find(Boolean);
-    if (candidate) return candidate;
-  }
-
-  const xfwd = request?.headers?.['x-forwarded-for'];
-  if (xfwd && typeof xfwd === 'string') {
-    const forwardedIp = xfwd.split(',').map((ip) => ip.trim()).find(Boolean);
-    if (forwardedIp) return forwardedIp;
-  }
-
-  const xReal = request?.headers?.['x-real-ip'];
-  if (xReal) return xReal;
-
-  const cfIp = request?.headers?.['cf-connecting-ip'];
-  if (cfIp) return cfIp;
-
-  const forwardedHeader = request?.headers?.forwarded;
-  if (forwardedHeader && typeof forwardedHeader === 'string') {
-    const match = forwardedHeader.match(/for=([^;]+)/i);
-    if (match && match[1]) {
-      return match[1].replace(/["[\]]/g, '');
-    }
-  }
-
-  return (
-    request?.ip ||
-    request?.socket?.remoteAddress ||
-    request?.raw?.socket?.remoteAddress ||
-    'unknown'
-  );
-}
 
 async function getActiveMembershipDetails(userId) {
   const memberships = await Membership.find({
@@ -241,7 +207,7 @@ class AuthService {
   }
 
   async login(email, password, tenantId, request = null) {
-    const clientIp = extractClientIp(request);
+    const clientIp = extractTrustedClientIp(request);
     const userAgent = request?.headers?.['user-agent'] || 'unknown';
 
     const blockStatus = await loginRateLimiter.isBlocked(email, clientIp);

--- a/apps/api/src/services/clientIp.js
+++ b/apps/api/src/services/clientIp.js
@@ -1,0 +1,42 @@
+const net = require('node:net');
+
+function firstHeaderValue(value) {
+  if (Array.isArray(value)) {
+    return value.find(Boolean) || '';
+  }
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeIp(value) {
+  const candidate = firstHeaderValue(value);
+  if (!candidate) return null;
+
+  const unwrapped = candidate.startsWith('[') && candidate.endsWith(']')
+    ? candidate.slice(1, -1)
+    : candidate;
+
+  return net.isIP(unwrapped) ? unwrapped.toLowerCase() : null;
+}
+
+/**
+ * Resolve the security-sensitive client identifier without trusting the
+ * attacker-controlled left-most X-Forwarded-For value. Production traffic is
+ * required to pass through Cloudflare, which overwrites CF-Connecting-IP.
+ * Direct/local traffic falls back to the TCP peer address.
+ */
+function extractTrustedClientIp(request) {
+  const cloudflareIp = normalizeIp(request?.headers?.['cf-connecting-ip']);
+  if (cloudflareIp) return cloudflareIp;
+
+  const socketIp = normalizeIp(
+    request?.raw?.socket?.remoteAddress || request?.socket?.remoteAddress
+  );
+  if (socketIp) return socketIp;
+
+  return 'unknown';
+}
+
+module.exports = {
+  extractTrustedClientIp,
+  normalizeIp,
+};

--- a/apps/api/src/services/clientIp.test.mjs
+++ b/apps/api/src/services/clientIp.test.mjs
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { extractTrustedClientIp } = require('./clientIp');
+
+describe('extractTrustedClientIp', () => {
+  it('prefers Cloudflare client identity over a forged forwarding chain', () => {
+    const request = {
+      headers: {
+        'cf-connecting-ip': '203.0.113.45',
+        'x-forwarded-for': '1.2.3.4, 203.0.113.45',
+      },
+      ips: ['1.2.3.4', '203.0.113.45'],
+      raw: { socket: { remoteAddress: '172.16.0.10' } },
+    };
+
+    expect(extractTrustedClientIp(request)).toBe('203.0.113.45');
+  });
+
+  it('ignores forwarding headers when Cloudflare identity is absent', () => {
+    const request = {
+      headers: { 'x-forwarded-for': '1.2.3.4, 198.51.100.10' },
+      ips: ['1.2.3.4', '198.51.100.10'],
+      raw: { socket: { remoteAddress: '127.0.0.1' } },
+    };
+
+    expect(extractTrustedClientIp(request)).toBe('127.0.0.1');
+  });
+});

--- a/apps/api/src/services/collectionEntryService.js
+++ b/apps/api/src/services/collectionEntryService.js
@@ -390,7 +390,62 @@ async function generateUniqueSlug({ tenantId, collectionKey, baseSlug, excludeId
   return candidate;
 }
 
-async function normaliseAndValidateData({ collectionType, data }) {
+async function validateDataReferenceOwnership({ tenantId, collectionType, data }) {
+  const errors = [];
+  const refFields = (collectionType.fields || []).filter((field) => field.type === 'ref');
+  const mediaFields = (collectionType.fields || []).filter((field) => field.type === 'media');
+  const refIds = new Set();
+  const mediaIds = new Set();
+
+  refFields.forEach((field) => {
+    ensureArrayValue(data[field.key]).forEach((id) => refIds.add(id.toString()));
+  });
+  mediaFields.forEach((field) => {
+    ensureArrayValue(data[field.key]).forEach((id) => mediaIds.add(id.toString()));
+  });
+
+  const [refDocs, mediaDocs] = await Promise.all([
+    refIds.size
+      ? CollectionEntry.find({ tenantId, _id: { $in: Array.from(refIds) } })
+          .select('_id collectionKey')
+          .lean()
+      : [],
+    mediaIds.size
+      ? Media.find({ tenantId, _id: { $in: Array.from(mediaIds) } })
+          .select('_id')
+          .lean()
+      : [],
+  ]);
+
+  const ownedRefs = new Map(refDocs.map((doc) => [doc._id.toString(), doc.collectionKey]));
+  const ownedMedia = new Set(mediaDocs.map((doc) => doc._id.toString()));
+
+  refFields.forEach((field) => {
+    const invalid = ensureArrayValue(data[field.key]).some((id) => (
+      ownedRefs.get(id.toString()) !== field.ref
+    ));
+    if (invalid) {
+      errors.push({
+        field: field.key,
+        message: `Referenced entries must belong to this tenant and collection '${field.ref}'`,
+      });
+    }
+  });
+
+  mediaFields.forEach((field) => {
+    const invalid = ensureArrayValue(data[field.key]).some((id) => !ownedMedia.has(id.toString()));
+    if (invalid) {
+      errors.push({
+        field: field.key,
+        message: 'Referenced media must belong to this tenant',
+      });
+    }
+  });
+
+  return errors;
+}
+
+async function normaliseAndValidateData({ tenantId, collectionType, data }) {
   const output = {};
   const errors = [];
   const fields = collectionType.fields || [];
@@ -426,7 +481,62 @@ async function normaliseAndValidateData({ collectionType, data }) {
     }
   }
 
+  errors.push(...await validateDataReferenceOwnership({
+    tenantId,
+    collectionType,
+    data: output,
+  }));
+
   return { data: output, errors };
+}
+
+async function validateRelationsOwnership({ tenantId, relations }) {
+  const contentIds = (relations.contents || []).map((id) => id.toString());
+  const mediaIds = (relations.media || []).map((id) => id.toString());
+  const refIds = (relations.refs || []).map((ref) => ref.entryId.toString());
+
+  const [contentDocs, mediaDocs, refDocs] = await Promise.all([
+    contentIds.length
+      ? Content.find({ tenantId, _id: { $in: contentIds } }).select('_id').lean()
+      : [],
+    mediaIds.length
+      ? Media.find({ tenantId, _id: { $in: mediaIds } }).select('_id').lean()
+      : [],
+    refIds.length
+      ? CollectionEntry.find({ tenantId, _id: { $in: refIds } })
+          .select('_id collectionKey')
+          .lean()
+      : [],
+  ]);
+
+  const ownedContents = new Set(contentDocs.map((doc) => doc._id.toString()));
+  const ownedMedia = new Set(mediaDocs.map((doc) => doc._id.toString()));
+  const ownedRefs = new Map(refDocs.map((doc) => [doc._id.toString(), doc.collectionKey]));
+  const errors = [];
+
+  if (contentIds.some((id) => !ownedContents.has(id))) {
+    errors.push({ field: 'relations.contents', message: 'Related content must belong to this tenant' });
+  }
+  if (mediaIds.some((id) => !ownedMedia.has(id))) {
+    errors.push({ field: 'relations.media', message: 'Related media must belong to this tenant' });
+  }
+  if ((relations.refs || []).some((ref) => (
+    ownedRefs.get(ref.entryId.toString()) !== ref.collectionKey
+  ))) {
+    errors.push({
+      field: 'relations.refs',
+      message: 'Related entries must belong to this tenant and the declared collection',
+    });
+  }
+
+  return errors;
+}
+
+function throwEntryValidationError(details) {
+  const error = new Error('Entry validation failed');
+  error.code = 'EntryValidationFailed';
+  error.details = details;
+  throw error;
 }
 
 async function ensureUniqueFields({ tenantId, collectionKey, fields, data, excludeId }) {
@@ -616,17 +726,22 @@ async function listEntries({ tenantId, collectionKey, query }) {
 async function createEntry({ tenantId, collectionKey, payload, userId }) {
   const collectionType = await getCollectionType({ tenantId, key: collectionKey });
 
-  const { data, errors } = await normaliseAndValidateData({ collectionType, data: payload.data });
+  const { data, errors } = await normaliseAndValidateData({
+    tenantId,
+    collectionType,
+    data: payload.data,
+  });
   if (errors.length) {
-    const error = new Error('Entry validation failed');
-    error.code = 'EntryValidationFailed';
-    error.details = errors;
-    throw error;
+    throwEntryValidationError(errors);
   }
 
   await ensureUniqueFields({ tenantId, collectionKey, fields: collectionType.fields || [], data });
 
   const relations = normaliseRelations(payload.relations || {});
+  const relationErrors = await validateRelationsOwnership({ tenantId, relations });
+  if (relationErrors.length) {
+    throwEntryValidationError(relationErrors);
+  }
   const slug = await resolveSlug({ collectionType, tenantId, collectionKey, payload, data });
   const status = payload.status || 'draft';
 
@@ -676,17 +791,22 @@ async function updateEntry({ tenantId, collectionKey, entryId, payload, userId }
     ...(payload.data || {})
   };
 
-  const { data, errors } = await normaliseAndValidateData({ collectionType, data: mergedData });
+  const { data, errors } = await normaliseAndValidateData({
+    tenantId,
+    collectionType,
+    data: mergedData,
+  });
   if (errors.length) {
-    const error = new Error('Entry validation failed');
-    error.code = 'EntryValidationFailed';
-    error.details = errors;
-    throw error;
+    throwEntryValidationError(errors);
   }
 
   await ensureUniqueFields({ tenantId, collectionKey, fields: collectionType.fields || [], data, excludeId: existing._id });
 
   const relations = normaliseRelations(mergeRelations(existing.relations || {}, payload.relations || {}));
+  const relationErrors = await validateRelationsOwnership({ tenantId, relations });
+  if (relationErrors.length) {
+    throwEntryValidationError(relationErrors);
+  }
   const status = payload.status || existing.status;
 
   const slug = await resolveSlug({
@@ -937,7 +1057,8 @@ async function runCollectionQuery({ tenantId, payload }) {
 
   const baseQuery = {
     tenantId,
-    collectionKey: payload.collection
+    collectionKey: payload.collection,
+    status: 'published',
   };
 
   const whereClauses = [];
@@ -1101,9 +1222,28 @@ async function runCollectionQuery({ tenantId, payload }) {
   }
 
   const [refDocs, mediaDocs, contentDocs] = await Promise.all([
-    refIdSet.size ? CollectionEntry.find({ _id: { $in: Array.from(refIdSet) } }).lean() : [],
-    mediaIdSet.size ? Media.find({ _id: { $in: Array.from(mediaIdSet) } }).lean() : [],
-    contentIdSet.size ? Content.find({ _id: { $in: Array.from(contentIdSet) } }).lean() : []
+    refIdSet.size
+      ? CollectionEntry.find({
+          tenantId,
+          status: 'published',
+          _id: { $in: Array.from(refIdSet) },
+        }).lean()
+      : [],
+    mediaIdSet.size
+      ? Media.find({
+          tenantId,
+          status: 'active',
+          isPublic: { $ne: false },
+          _id: { $in: Array.from(mediaIdSet) },
+        }).lean()
+      : [],
+    contentIdSet.size
+      ? Content.find({
+          tenantId,
+          status: 'published',
+          _id: { $in: Array.from(contentIdSet) },
+        }).lean()
+      : []
   ]);
 
   const refCache = new Map(refDocs.map((doc) => [doc._id.toString(), doc]));

--- a/apps/api/src/services/collectionEntryService.security.test.mjs
+++ b/apps/api/src/services/collectionEntryService.security.test.mjs
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const mongoose = require('mongoose');
+const common = require('@contexthub/common');
+const collectionTypeService = require('./collectionTypeService');
+
+let collectionEntryService;
+let getCollectionTypeSpy;
+
+function listQueryResult(items) {
+  return {
+    sort: vi.fn().mockReturnThis(),
+    skip: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    lean: vi.fn().mockResolvedValue(items),
+  };
+}
+
+function selectedQueryResult(items) {
+  return {
+    select: vi.fn().mockReturnValue({
+      lean: vi.fn().mockResolvedValue(items),
+    }),
+  };
+}
+
+beforeEach(() => {
+  getCollectionTypeSpy = vi.spyOn(collectionTypeService, 'getCollectionType');
+  delete require.cache[require.resolve('./collectionEntryService')];
+  collectionEntryService = require('./collectionEntryService');
+  getCollectionTypeSpy.mockResolvedValue({
+    fields: [],
+    settings: {},
+    toObject() {
+      return { fields: this.fields, settings: this.settings };
+    },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('collection entry tenant boundaries', () => {
+  it('forces every public DSL base query to published entries', async () => {
+    const findSpy = vi.spyOn(common.CollectionEntry, 'find').mockReturnValue(listQueryResult([]));
+    vi.spyOn(common.CollectionEntry, 'countDocuments').mockResolvedValue(0);
+
+    await collectionEntryService.runCollectionQuery({
+      tenantId: '64b000000000000000000001',
+      payload: { collection: 'people', limit: 20 },
+    });
+
+    expect(findSpy).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: '64b000000000000000000001',
+      collectionKey: 'people',
+      status: 'published',
+    }));
+    expect(common.CollectionEntry.countDocuments).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'published',
+    }));
+  });
+
+  it('scopes expanded refs, media and content to the tenant and public state', async () => {
+    const tenantId = '64b000000000000000000001';
+    const entryId = new mongoose.Types.ObjectId();
+    const refId = new mongoose.Types.ObjectId();
+    const mediaId = new mongoose.Types.ObjectId();
+    const contentId = new mongoose.Types.ObjectId();
+
+    getCollectionTypeSpy.mockResolvedValue({
+      fields: [
+        { key: 'author', type: 'ref', ref: 'people', settings: {} },
+        { key: 'image', type: 'media', settings: {} },
+      ],
+      settings: {},
+      toObject() {
+        return { fields: this.fields, settings: this.settings };
+      },
+    });
+
+    const entry = {
+      _id: entryId,
+      data: { author: refId, image: mediaId },
+      relations: { media: [mediaId], contents: [contentId] },
+    };
+    const entryFindSpy = vi.spyOn(common.CollectionEntry, 'find').mockImplementation((query) => {
+      if (query.collectionKey) return listQueryResult([entry]);
+      return { lean: vi.fn().mockResolvedValue([]) };
+    });
+    vi.spyOn(common.CollectionEntry, 'countDocuments').mockResolvedValue(1);
+    const mediaFindSpy = vi.spyOn(common.Media, 'find').mockReturnValue({
+      lean: vi.fn().mockResolvedValue([]),
+    });
+    const contentFindSpy = vi.spyOn(common.Content, 'find').mockReturnValue({
+      lean: vi.fn().mockResolvedValue([]),
+    });
+
+    await collectionEntryService.runCollectionQuery({
+      tenantId,
+      payload: {
+        collection: 'articles',
+        select: ['author.slug', 'image.url', 'relations.media.url', 'relations.contents.title'],
+      },
+    });
+
+    expect(entryFindSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      tenantId,
+      status: 'published',
+    }));
+    expect(mediaFindSpy).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId,
+      status: 'active',
+      isPublic: { $ne: false },
+    }));
+    expect(contentFindSpy).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId,
+      status: 'published',
+    }));
+  });
+
+  it('rejects cross-tenant field references before creating an entry', async () => {
+    const foreignRefId = new mongoose.Types.ObjectId();
+    getCollectionTypeSpy.mockResolvedValue({
+      fields: [{ key: 'author', type: 'ref', ref: 'people', settings: {} }],
+      settings: {},
+    });
+
+    vi.spyOn(common.CollectionEntry, 'find').mockReturnValue(selectedQueryResult([]));
+    const createSpy = vi.spyOn(common.CollectionEntry, 'create');
+
+    await expect(collectionEntryService.createEntry({
+      tenantId: '64b000000000000000000001',
+      collectionKey: 'articles',
+      payload: { data: { author: foreignRefId.toString() } },
+      userId: new mongoose.Types.ObjectId().toString(),
+    })).rejects.toMatchObject({
+      code: 'EntryValidationFailed',
+      details: expect.arrayContaining([expect.objectContaining({ field: 'author' })]),
+    });
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/loginRateLimiter.js
+++ b/apps/api/src/services/loginRateLimiter.js
@@ -1,75 +1,123 @@
 const crypto = require('crypto');
 const localRedisClient = require('../lib/localRedis');
 
-const MAX_ATTEMPTS = 5;
-const BLOCK_TTL_SECONDS = process.env.NODE_ENV === 'development' ? 60 : 60 * 60; // 1 min dev, 1 hour prod
-const ATTEMPT_TTL_SECONDS = process.env.NODE_ENV === 'development' ? 60 : 60 * 60; // Track attempts over window
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
-// Fallback in-memory store when Redis is unavailable (non-persistent)
+const EMAIL_MAX_ATTEMPTS = positiveInteger(process.env.LOGIN_EMAIL_MAX_ATTEMPTS, 5);
+const IP_MAX_ATTEMPTS = positiveInteger(process.env.LOGIN_IP_MAX_ATTEMPTS, 20);
+const BLOCK_TTL_SECONDS = process.env.NODE_ENV === 'development' ? 60 : 60 * 60;
+const ATTEMPT_TTL_SECONDS = process.env.NODE_ENV === 'development' ? 60 : 60 * 60;
+
+// Fallback in-memory store when Redis is unavailable (non-persistent).
 const memoryStore = new Map();
 
-function buildKey(email = '', ip = '') {
-  const normalizedEmail = (email || '').trim().toLowerCase();
-  const normalizedIp = (ip || '').trim().toLowerCase() || 'unknown';
-  const raw = `${normalizedEmail}|${normalizedIp}`;
-  return crypto.createHash('sha256').update(raw).digest('hex');
+function hashScope(scope, value) {
+  return crypto.createHash('sha256').update(`${scope}:${value}`).digest('hex');
+}
+
+function normalizeEmail(email = '') {
+  return String(email || '').trim().toLowerCase() || 'unknown';
+}
+
+function normalizeIp(ip = '') {
+  return String(ip || '').trim().toLowerCase() || 'unknown';
+}
+
+function getBuckets(email, ip) {
+  return [
+    {
+      scope: 'email',
+      key: hashScope('email', normalizeEmail(email)),
+      maxAttempts: EMAIL_MAX_ATTEMPTS,
+    },
+    {
+      scope: 'ip',
+      key: hashScope('ip', normalizeIp(ip)),
+      maxAttempts: IP_MAX_ATTEMPTS,
+    },
+  ];
+}
+
+function blockKey(bucket) {
+  return `login:block:${bucket.scope}:${bucket.key}`;
+}
+
+function attemptKey(bucket) {
+  return `login:attempts:${bucket.scope}:${bucket.key}`;
+}
+
+function combineBlockedStates(states) {
+  const blockedStates = states.filter((state) => state.blocked);
+  return {
+    blocked: blockedStates.length > 0,
+    retryAfterSeconds: blockedStates.length
+      ? Math.max(...blockedStates.map((state) => state.retryAfterSeconds || 0))
+      : 0,
+    blockedScopes: blockedStates.map((state) => state.scope),
+  };
 }
 
 async function isBlocked(email, ip) {
-  const key = buildKey(email, ip);
+  const buckets = getBuckets(email, ip);
 
   if (localRedisClient.isEnabled()) {
     try {
       const client = localRedisClient.getClient();
-      const blockKey = `login:block:${key}`;
-      const ttl = await client.ttl(blockKey);
-      if (ttl && ttl > 0) {
-        return { blocked: true, retryAfterSeconds: ttl };
-      }
-      return { blocked: false, retryAfterSeconds: 0 };
+      const states = await Promise.all(buckets.map(async (bucket) => {
+        const ttl = await client.ttl(blockKey(bucket));
+        return {
+          scope: bucket.scope,
+          blocked: Number.isFinite(ttl) && ttl > 0,
+          retryAfterSeconds: Number.isFinite(ttl) && ttl > 0 ? ttl : 0,
+        };
+      }));
+      return combineBlockedStates(states);
     } catch (error) {
       console.error('[LoginLimiter] Redis block check failed:', error.message);
     }
   }
 
-  const entry = memoryStore.get(key);
-  if (entry && entry.blockUntil && entry.blockUntil > Date.now()) {
-    const retryAfterSeconds = Math.ceil((entry.blockUntil - Date.now()) / 1000);
-    return { blocked: true, retryAfterSeconds };
-  }
+  const now = Date.now();
+  const states = buckets.map((bucket) => {
+    const entry = memoryStore.get(`${bucket.scope}:${bucket.key}`);
+    const blocked = Boolean(entry?.blockUntil && entry.blockUntil > now);
+    return {
+      scope: bucket.scope,
+      blocked,
+      retryAfterSeconds: blocked ? Math.ceil((entry.blockUntil - now) / 1000) : 0,
+    };
+  });
 
-  return { blocked: false, retryAfterSeconds: 0 };
+  return combineBlockedStates(states);
 }
 
-async function recordFailedAttempt(email, ip) {
-  const key = buildKey(email, ip);
+async function recordRedisFailure(client, bucket) {
+  const attemptsKey = attemptKey(bucket);
+  const attempts = await client.incr(attemptsKey);
 
-  if (localRedisClient.isEnabled()) {
-    try {
-      const client = localRedisClient.getClient();
-      const attemptKey = `login:attempts:${key}`;
-      const blockKey = `login:block:${key}`;
-
-      const attempts = await client.incr(attemptKey);
-
-      if (attempts === 1) {
-        await client.expire(attemptKey, ATTEMPT_TTL_SECONDS);
-      }
-
-      if (attempts >= MAX_ATTEMPTS) {
-        await client.set(blockKey, '1', { EX: BLOCK_TTL_SECONDS });
-        await client.del(attemptKey);
-        return { attempts: MAX_ATTEMPTS, blocked: true };
-      }
-
-      return { attempts, blocked: false };
-    } catch (error) {
-      console.error('[LoginLimiter] Redis record failed attempt error:', error.message);
-    }
+  if (attempts === 1) {
+    await client.expire(attemptsKey, ATTEMPT_TTL_SECONDS);
   }
 
-  const entry = memoryStore.get(key) || { attempts: 0, expiresAt: Date.now() + ATTEMPT_TTL_SECONDS * 1000 };
+  if (attempts >= bucket.maxAttempts) {
+    await client.set(blockKey(bucket), '1', { EX: BLOCK_TTL_SECONDS });
+    await client.del(attemptsKey);
+    return { scope: bucket.scope, attempts: bucket.maxAttempts, blocked: true };
+  }
+
+  return { scope: bucket.scope, attempts, blocked: false };
+}
+
+function recordMemoryFailure(bucket) {
+  const key = `${bucket.scope}:${bucket.key}`;
   const now = Date.now();
+  const entry = memoryStore.get(key) || {
+    attempts: 0,
+    expiresAt: now + ATTEMPT_TTL_SECONDS * 1000,
+  };
 
   if (entry.expiresAt < now) {
     entry.attempts = 0;
@@ -77,40 +125,81 @@ async function recordFailedAttempt(email, ip) {
   }
 
   entry.attempts += 1;
-
-  if (entry.attempts >= MAX_ATTEMPTS) {
+  if (entry.attempts >= bucket.maxAttempts) {
     entry.blockUntil = now + BLOCK_TTL_SECONDS * 1000;
     entry.attempts = 0;
     memoryStore.set(key, entry);
-    return { attempts: MAX_ATTEMPTS, blocked: true };
+    return { scope: bucket.scope, attempts: bucket.maxAttempts, blocked: true };
   }
 
   memoryStore.set(key, entry);
-  return { attempts: entry.attempts, blocked: false };
+  return { scope: bucket.scope, attempts: entry.attempts, blocked: false };
 }
 
-async function reset(email, ip) {
-  const key = buildKey(email, ip);
+function summarizeAttempts(results) {
+  const emailResult = results.find((result) => result.scope === 'email');
+  return {
+    attempts: emailResult?.attempts || 0,
+    blocked: results.some((result) => result.blocked),
+    blockedScopes: results.filter((result) => result.blocked).map((result) => result.scope),
+  };
+}
+
+async function recordFailedAttempt(email, ip) {
+  const buckets = getBuckets(email, ip);
 
   if (localRedisClient.isEnabled()) {
     try {
       const client = localRedisClient.getClient();
-      await client.del(`login:attempts:${key}`);
-      await client.del(`login:block:${key}`);
+      const results = [];
+      for (const bucket of buckets) {
+        results.push(await recordRedisFailure(client, bucket));
+      }
+      return summarizeAttempts(results);
+    } catch (error) {
+      console.error('[LoginLimiter] Redis record failed attempt error:', error.message);
+    }
+  }
+
+  return summarizeAttempts(buckets.map(recordMemoryFailure));
+}
+
+/**
+ * A successful login clears only the account bucket. Clearing the IP bucket
+ * would let an attacker use one known credential to reset a credential-
+ * stuffing limit for every other account.
+ */
+async function reset(email) {
+  const emailBucket = getBuckets(email, 'unknown')[0];
+  const memoryKey = `${emailBucket.scope}:${emailBucket.key}`;
+
+  if (localRedisClient.isEnabled()) {
+    try {
+      const client = localRedisClient.getClient();
+      await client.del(attemptKey(emailBucket));
+      await client.del(blockKey(emailBucket));
+      memoryStore.delete(memoryKey);
       return true;
     } catch (error) {
       console.error('[LoginLimiter] Redis reset failed:', error.message);
     }
   }
 
-  memoryStore.delete(key);
+  memoryStore.delete(memoryKey);
   return true;
+}
+
+function __resetMemoryStore() {
+  memoryStore.clear();
 }
 
 module.exports = {
   isBlocked,
   recordFailedAttempt,
   reset,
-  MAX_ATTEMPTS,
-  BLOCK_TTL_SECONDS
+  EMAIL_MAX_ATTEMPTS,
+  IP_MAX_ATTEMPTS,
+  MAX_ATTEMPTS: EMAIL_MAX_ATTEMPTS,
+  BLOCK_TTL_SECONDS,
+  __resetMemoryStore,
 };

--- a/apps/api/src/services/loginRateLimiter.test.mjs
+++ b/apps/api/src/services/loginRateLimiter.test.mjs
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const localRedisClient = require('../lib/localRedis');
+const limiter = require('./loginRateLimiter');
+
+describe('loginRateLimiter', () => {
+  beforeEach(() => {
+    vi.spyOn(localRedisClient, 'isEnabled').mockReturnValue(false);
+    limiter.__resetMemoryStore();
+  });
+
+  it('blocks a targeted email even when the attacker rotates IP addresses', async () => {
+    for (let attempt = 1; attempt <= limiter.EMAIL_MAX_ATTEMPTS; attempt += 1) {
+      await limiter.recordFailedAttempt('victim@example.com', `198.51.100.${attempt}`);
+    }
+
+    const status = await limiter.isBlocked('victim@example.com', '203.0.113.200');
+    expect(status.blocked).toBe(true);
+    expect(status.blockedScopes).toContain('email');
+  });
+
+  it('blocks credential stuffing from one IP across different emails', async () => {
+    for (let attempt = 1; attempt <= limiter.IP_MAX_ATTEMPTS; attempt += 1) {
+      await limiter.recordFailedAttempt(`person-${attempt}@example.com`, '198.51.100.50');
+    }
+
+    const status = await limiter.isBlocked('fresh@example.com', '198.51.100.50');
+    expect(status.blocked).toBe(true);
+    expect(status.blockedScopes).toContain('ip');
+  });
+
+  it('does not clear the IP bucket after a successful account login', async () => {
+    for (let attempt = 1; attempt < limiter.IP_MAX_ATTEMPTS; attempt += 1) {
+      await limiter.recordFailedAttempt(`person-${attempt}@example.com`, '198.51.100.75');
+    }
+
+    await limiter.reset('known-good@example.com', '198.51.100.75');
+    await limiter.recordFailedAttempt('last@example.com', '198.51.100.75');
+
+    const status = await limiter.isBlocked('another@example.com', '198.51.100.75');
+    expect(status.blockedScopes).toContain('ip');
+  });
+});

--- a/apps/api/src/services/webhookService.js
+++ b/apps/api/src/services/webhookService.js
@@ -9,10 +9,16 @@ const {
   retryJobsByWebhookId,
   deleteJobsByWebhookId
 } = require('../lib/webhookDispatcher');
+const {
+  closeWebhookDispatcher,
+  prepareSafeWebhookRequest,
+  validateWebhookUrl
+} = require('./webhookUrlSecurity');
 
 const webhookServiceDeps = {
   fetch,
-  signPayload
+  signPayload,
+  prepareSafeWebhookRequest
 };
 
 const EVENT_SET = new Set(DOMAIN_EVENT_TYPES);
@@ -71,18 +77,6 @@ function generateSecret() {
   return crypto.randomBytes(32).toString('hex');
 }
 
-function validateUrl(value) {
-  if (!value || typeof value !== 'string' || !value.trim()) {
-    throw new Error('Webhook URL is required');
-  }
-  try {
-    new URL(value.trim());
-  } catch (error) {
-    throw new Error('Webhook URL is invalid');
-  }
-  return value.trim();
-}
-
 function normalizeEvents(eventsInput) {
   if (!Array.isArray(eventsInput) || eventsInput.length === 0) {
     return ['*'];
@@ -137,7 +131,7 @@ async function listWebhooks(tenantId) {
 
 async function createWebhook(tenantId, payload = {}) {
   const normalizedTenantId = ensureTenantId(tenantId);
-  const url = validateUrl(payload.url);
+  const url = validateWebhookUrl(payload.url);
   const events = normalizeEvents(payload.events);
   const isActive = payload.isActive !== undefined ? Boolean(payload.isActive) : true;
   const secret = payload.secret && payload.secret.trim() ? payload.secret.trim() : generateSecret();
@@ -163,7 +157,7 @@ async function updateWebhook(tenantId, webhookId, payload = {}) {
   const updates = {};
 
   if (payload.url !== undefined) {
-    updates.url = validateUrl(payload.url);
+    updates.url = validateWebhookUrl(payload.url);
   }
 
   if (payload.isActive !== undefined) {
@@ -370,20 +364,29 @@ async function sendTestWebhook(tenantId, webhookId, payloadOverride = null) {
   const body = JSON.stringify(domainEventPayload);
   const signature = webhookServiceDeps.signPayload(webhook.secret, body);
   const startTime = Date.now();
-  const response = await webhookServiceDeps.fetch(webhook.url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-CTXHUB-SIGNATURE': signature,
-      'X-CTXHUB-EVENT': domainEventPayload.type
-    },
-    body,
-    signal: typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
-      ? AbortSignal.timeout(5000)
-      : undefined
-  });
+  const prepared = await webhookServiceDeps.prepareSafeWebhookRequest(webhook.url);
+  let response;
+  let responseBody;
+  try {
+    response = await webhookServiceDeps.fetch(prepared.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CTXHUB-SIGNATURE': signature,
+        'X-CTXHUB-EVENT': domainEventPayload.type
+      },
+      body,
+      redirect: 'error',
+      dispatcher: prepared.dispatcher,
+      signal: typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
+        ? AbortSignal.timeout(5000)
+        : undefined
+    });
+    responseBody = await readResponseSnippet(response);
+  } finally {
+    await closeWebhookDispatcher(prepared.dispatcher);
+  }
   const durationMs = Date.now() - startTime;
-  const responseBody = await readResponseSnippet(response);
 
   if (!response.ok) {
     console.error('[webhookService] Test webhook failed', {
@@ -410,6 +413,8 @@ async function sendTestWebhook(tenantId, webhookId, payloadOverride = null) {
 function __setWebhookServiceDeps(overrides = {}) {
   webhookServiceDeps.fetch = overrides.fetch || fetch;
   webhookServiceDeps.signPayload = overrides.signPayload || signPayload;
+  webhookServiceDeps.prepareSafeWebhookRequest = overrides.prepareSafeWebhookRequest
+    || prepareSafeWebhookRequest;
 }
 
 /**

--- a/apps/api/src/services/webhookService.test.js
+++ b/apps/api/src/services/webhookService.test.js
@@ -15,11 +15,17 @@ describe('sendTestWebhook', () => {
   let findOneSpy
   let mockFetch
   let mockSignPayload
+  let mockPrepareSafeWebhookRequest
 
   beforeEach(() => {
     mockFetch = vi.fn()
     mockSignPayload = vi.fn(() => 'mock-signature')
-    setWebhookDeps({ fetch: mockFetch, signPayload: mockSignPayload })
+    mockPrepareSafeWebhookRequest = vi.fn(async (url) => ({ url }))
+    setWebhookDeps({
+      fetch: mockFetch,
+      signPayload: mockSignPayload,
+      prepareSafeWebhookRequest: mockPrepareSafeWebhookRequest
+    })
 
     findOneSpy = vi.spyOn(Webhook, 'findOne').mockReturnValue({
       lean: () =>
@@ -45,6 +51,7 @@ describe('sendTestWebhook', () => {
     const result = await sendTestWebhook('tenant_1', 'hook123')
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockPrepareSafeWebhookRequest).toHaveBeenCalledWith('https://example.com/webhook')
     const [url, options] = mockFetch.mock.calls[0]
     expect(url).toBe('https://example.com/webhook')
     expect(options.headers['X-CTXHUB-EVENT']).toBe('webhook.test')

--- a/apps/api/src/services/webhookUrlSecurity.js
+++ b/apps/api/src/services/webhookUrlSecurity.js
@@ -1,0 +1,172 @@
+const dns = require('node:dns').promises;
+const net = require('node:net');
+const { Agent } = require('undici');
+
+const blockedAddresses = new net.BlockList();
+
+[
+  ['0.0.0.0', 8],
+  ['10.0.0.0', 8],
+  ['100.64.0.0', 10],
+  ['127.0.0.0', 8],
+  ['169.254.0.0', 16],
+  ['172.16.0.0', 12],
+  ['192.0.0.0', 24],
+  ['192.0.2.0', 24],
+  ['192.168.0.0', 16],
+  ['198.18.0.0', 15],
+  ['198.51.100.0', 24],
+  ['203.0.113.0', 24],
+  ['224.0.0.0', 4],
+  ['240.0.0.0', 4],
+].forEach(([address, prefix]) => blockedAddresses.addSubnet(address, prefix, 'ipv4'));
+
+[
+  ['::', 96],
+  ['::1', 128],
+  ['fc00::', 7],
+  ['fec0::', 10],
+  ['fe80::', 10],
+  ['ff00::', 8],
+  ['2001:db8::', 32],
+].forEach(([address, prefix]) => blockedAddresses.addSubnet(address, prefix, 'ipv6'));
+
+function securityError(message) {
+  const error = new Error(message);
+  error.code = 'WEBHOOK_URL_BLOCKED';
+  return error;
+}
+
+function allowPrivateTargets() {
+  return process.env.NODE_ENV !== 'production'
+    && ['1', 'true', 'yes', 'on'].includes(
+      String(process.env.WEBHOOK_ALLOW_PRIVATE_TARGETS || '').trim().toLowerCase()
+    );
+}
+
+function allowInsecureHttp() {
+  if (process.env.NODE_ENV !== 'production') return true;
+  return false;
+}
+
+function unwrapHostname(hostname) {
+  return hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+}
+
+function isBlockedAddress(address, family = net.isIP(address)) {
+  if (!family) return true;
+
+  if (family === 6) {
+    const mapped = address.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+    if (mapped) {
+      return isBlockedAddress(mapped[1], 4);
+    }
+  }
+
+  return blockedAddresses.check(address, family === 6 ? 'ipv6' : 'ipv4');
+}
+
+function validateWebhookUrl(value) {
+  if (!value || typeof value !== 'string' || !value.trim()) {
+    throw new Error('Webhook URL is required');
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(value.trim());
+  } catch (error) {
+    throw new Error('Webhook URL is invalid');
+  }
+
+  if (!['https:', 'http:'].includes(parsed.protocol)) {
+    throw securityError('Webhook URL must use HTTP or HTTPS');
+  }
+  if (parsed.protocol !== 'https:' && !allowInsecureHttp()) {
+    throw securityError('Webhook URL must use HTTPS in production');
+  }
+  if (parsed.username || parsed.password) {
+    throw securityError('Webhook URL must not include credentials');
+  }
+
+  const hostname = unwrapHostname(parsed.hostname).toLowerCase();
+  if (!hostname) {
+    throw new Error('Webhook URL is invalid');
+  }
+
+  const localHostname = hostname === 'localhost'
+    || hostname.endsWith('.localhost')
+    || hostname.endsWith('.local')
+    || hostname.endsWith('.internal')
+    || hostname.endsWith('.home.arpa');
+
+  if (!allowPrivateTargets() && localHostname) {
+    throw securityError('Webhook URL must not target a local or internal host');
+  }
+
+  const literalFamily = net.isIP(hostname);
+  if (!allowPrivateTargets() && literalFamily && isBlockedAddress(hostname, literalFamily)) {
+    throw securityError('Webhook URL must not target a private or reserved address');
+  }
+
+  return parsed.toString();
+}
+
+async function prepareSafeWebhookRequest(value, options = {}) {
+  const url = validateWebhookUrl(value);
+  const parsed = new URL(url);
+  const hostname = unwrapHostname(parsed.hostname);
+  const lookup = options.lookup || dns.lookup;
+  const literalFamily = net.isIP(hostname);
+  const records = literalFamily
+    ? [{ address: hostname, family: literalFamily }]
+    : await lookup(hostname, { all: true, verbatim: true });
+
+  if (!Array.isArray(records) || records.length === 0) {
+    throw securityError('Webhook hostname did not resolve');
+  }
+
+  const normalizedRecords = records.map((record) => ({
+    address: record.address,
+    family: Number(record.family) || net.isIP(record.address),
+  }));
+
+  if (!allowPrivateTargets() && normalizedRecords.some((record) => (
+    isBlockedAddress(record.address, record.family)
+  ))) {
+    throw securityError('Webhook hostname resolves to a private or reserved address');
+  }
+
+  const pinned = normalizedRecords[0];
+  const dispatcher = new Agent({
+    connect: {
+      lookup(requestedHostname, lookupOptions, callback) {
+        if (requestedHostname.toLowerCase() !== hostname.toLowerCase()) {
+          callback(securityError('Webhook redirect target is not allowed'));
+          return;
+        }
+        if (lookupOptions?.all) {
+          callback(null, [pinned]);
+          return;
+        }
+        callback(null, pinned.address, pinned.family);
+      },
+    },
+  });
+
+  return { url, dispatcher };
+}
+
+async function closeWebhookDispatcher(dispatcher) {
+  if (dispatcher && typeof dispatcher.close === 'function') {
+    await dispatcher.close();
+  }
+}
+
+module.exports = {
+  closeWebhookDispatcher,
+  isBlockedAddress,
+  prepareSafeWebhookRequest,
+  validateWebhookUrl,
+};

--- a/apps/api/src/services/webhookUrlSecurity.test.mjs
+++ b/apps/api/src/services/webhookUrlSecurity.test.mjs
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  closeWebhookDispatcher,
+  prepareSafeWebhookRequest,
+  validateWebhookUrl,
+} = require('./webhookUrlSecurity');
+
+describe('webhook URL security', () => {
+  let originalNodeEnv;
+  let originalPrivateOverride;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    originalPrivateOverride = process.env.WEBHOOK_ALLOW_PRIVATE_TARGETS;
+    process.env.NODE_ENV = 'production';
+    delete process.env.WEBHOOK_ALLOW_PRIVATE_TARGETS;
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    if (originalPrivateOverride === undefined) delete process.env.WEBHOOK_ALLOW_PRIVATE_TARGETS;
+    else process.env.WEBHOOK_ALLOW_PRIVATE_TARGETS = originalPrivateOverride;
+  });
+
+  it('accepts public HTTPS targets', () => {
+    expect(validateWebhookUrl('https://hooks.example.com/events')).toBe(
+      'https://hooks.example.com/events'
+    );
+  });
+
+  it.each([
+    'http://hooks.example.com/events',
+    'file:///etc/passwd',
+    'https://user:password@hooks.example.com/events',
+    'https://localhost/events',
+    'https://127.0.0.1/events',
+    'https://[::7f00:1]/events',
+    'https://[::ffff:7f00:1]/events',
+  ])('rejects unsafe target %s', (url) => {
+    expect(() => validateWebhookUrl(url)).toThrow();
+  });
+
+  it('rejects hostnames that resolve to private addresses', async () => {
+    await expect(prepareSafeWebhookRequest('https://hooks.example.com/events', {
+      lookup: async () => [{ address: '10.10.0.5', family: 4 }],
+    })).rejects.toMatchObject({ code: 'WEBHOOK_URL_BLOCKED' });
+  });
+
+  it('pins a validated public DNS result for the outbound connection', async () => {
+    const prepared = await prepareSafeWebhookRequest('https://hooks.example.com/events', {
+      lookup: async () => [{ address: '93.184.216.34', family: 4 }],
+    });
+
+    expect(prepared.url).toBe('https://hooks.example.com/events');
+    expect(prepared.dispatcher).toBeTruthy();
+    await closeWebhookDispatcher(prepared.dispatcher);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@fastify/jwt':
         specifier: ^7.2.4
         version: 7.2.4
+      '@fastify/rate-limit':
+        specifier: ^9.1.0
+        version: 9.1.0
       '@fastify/swagger':
         specifier: ^8.15.0
         version: 8.15.0
@@ -859,6 +862,9 @@ packages:
 
   '@fastify/merge-json-schemas@0.1.1':
     resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
+
+  '@fastify/rate-limit@9.1.0':
+    resolution: {integrity: sha512-h5dZWCkuZXN0PxwqaFQLxeln8/LNwQwH9popywmDCFdKfgpi4b/HoMH1lluy6P+30CG9yzzpSpwTCIPNB9T1JA==}
 
   '@fastify/send@2.1.0':
     resolution: {integrity: sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==}
@@ -4360,6 +4366,12 @@ snapshots:
   '@fastify/merge-json-schemas@0.1.1':
     dependencies:
       fast-deep-equal: 3.1.3
+
+  '@fastify/rate-limit@9.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      fastify-plugin: 4.5.1
+      toad-cache: 3.7.1
 
   '@fastify/send@2.1.0':
     dependencies:


### PR DESCRIPTION
## Summary

- enforce tenant ownership and published-only boundaries for public collection DSL queries and relation expansion
- validate collection ref, media, and relation ownership before writes
- replace attacker-controlled forwarding-chain identity with trusted Cloudflare client IP resolution
- split failed-login tracking into independent per-email and per-IP buckets
- add server-wide and login-specific Fastify rate limits
- prevent webhook SSRF with protocol/host/address validation, DNS result pinning, private/reserved IP blocking, and redirect rejection

## Why

This addresses the launch-blocking T1, H1, N4, and N5 security findings. The previous implementation allowed cross-tenant/draft relation reads, login limiter bypass through rotating email/IP pairs and forged forwarding chains, an unthrottled login route, and outbound webhooks targeting internal services.

## Impact

Theme code and public response shapes are unchanged. Public relation expansion now returns only published/public resources from the active tenant. Production webhook targets must use HTTPS and resolve only to public addresses; existing HTTP or private/internal webhook targets will be rejected and should be migrated before rollout.

Rate-limit defaults and overrides are documented in `.env.example`.

## Validation

- `corepack pnpm --filter @contexthub/api test` — 37 test files and 171 tests passed
- final webhook URL security suite — 10 tests passed
- `corepack pnpm --filter @contexthub/api lint`
- `git diff --check`