### PR TITLE
Harden tenant-scoped content populates and mock auth boundary

### DIFF
--- a/apps/api/src/server.test.mjs
+++ b/apps/api/src/server.test.mjs
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 const require = createRequire(import.meta.url);
 const AuthService = require('./services/authService');
+const TEST_LOGIN_EMAIL = 'server-fixture@example.invalid';
+const TEST_LOGIN_PASSWORD = 'server-fixture-password';
 const TEST_R2_ENV = {
   R2_BUCKET: 'test-media-bucket',
   R2_PUBLIC_DOMAIN: 'https://media.example.test',
@@ -27,13 +29,13 @@ describe('API server', () => {
 
     originalLogin = AuthService.prototype.login;
     AuthService.prototype.login = async function mockLogin(email, password, tenantId) {
-      if (email === 'test@example.com' && password === '123456') {
+      if (email === TEST_LOGIN_EMAIL && password === TEST_LOGIN_PASSWORD) {
         const activeMembership = tenantId
           ? {
               id: 'membership-1',
               tenantId,
               tenant: { id: tenantId, name: 'Test Tenant', slug: 'test-tenant' },
-              role: 'admin',
+              role: 'editor',
               roleMeta: null,
               permissions: [],
               status: 'active',
@@ -110,7 +112,7 @@ describe('API server', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/auth/login',
-      payload: { email: 'test@example.com', password: '123456' },
+      payload: { email: TEST_LOGIN_EMAIL, password: TEST_LOGIN_PASSWORD },
     });
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.payload);
@@ -123,14 +125,14 @@ describe('API server', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/auth/login?tenantId=mock-tenant-id',
-      payload: { email: 'test@example.com', password: '123456' },
+      payload: { email: TEST_LOGIN_EMAIL, password: TEST_LOGIN_PASSWORD },
     });
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.payload);
     expect(body).not.toHaveProperty('token');
     expect(body.csrfToken).toBe('mock-csrf-token');
     expect(body).toHaveProperty('user');
-    expect(body.user.email).toBe('test@example.com');
+    expect(body.user.email).toBe(TEST_LOGIN_EMAIL);
     expect(res.headers['set-cookie']).toContain('ctx_session=mock-token');
     expect(res.headers['set-cookie']).toContain('HttpOnly');
     expect(res.headers['set-cookie']).toContain('SameSite=Strict');

--- a/apps/api/src/services/contentService.js
+++ b/apps/api/src/services/contentService.js
@@ -797,7 +797,7 @@ async function getContent({ tenantId, contentId }) {
   }
 
   const content = await Content.findOne({ _id: contentId, tenantId })
-    .populate('featuredMediaId')
+    .populate({ path: 'featuredMediaId', match: { tenantId } })
     .lean()
 
   if (!content) {
@@ -1001,7 +1001,7 @@ async function getContentBySlug({ tenantId, slug, status = null, publishedFrom =
 
   let content = await Content.findOne(query)
     .sort({ publishedAt: -1, createdAt: -1, _id: -1 })
-    .populate('featuredMediaId')
+    .populate({ path: 'featuredMediaId', match: { tenantId } })
     .lean()
 
   if (!content && publishedRange) {
@@ -1011,7 +1011,7 @@ async function getContentBySlug({ tenantId, slug, status = null, publishedFrom =
 
     content = await Content.findOne(scheduleQuery)
       .sort({ publishAt: -1, createdAt: -1, _id: -1 })
-      .populate('featuredMediaId')
+      .populate({ path: 'featuredMediaId', match: { tenantId } })
       .lean()
   }
 
@@ -1171,9 +1171,13 @@ async function listContents({ tenantId, filters = {}, pagination = {} }) {
       .sort({ publishedAt: -1 })
       .skip(skip)
       .limit(limit)
-      .populate('categories', 'name slug')
-      .populate('tags', 'slug title')
-      .populate('featuredMediaId', 'url title altText variants')
+      .populate({ path: 'categories', match: { tenantId }, select: 'name slug' })
+      .populate({ path: 'tags', match: { tenantId }, select: 'slug title' })
+      .populate({
+        path: 'featuredMediaId',
+        match: { tenantId },
+        select: 'url title altText variants'
+      })
       .lean(),
     Content.countDocuments(query)
   ])

--- a/apps/api/src/services/contentService.tenantScope.test.mjs
+++ b/apps/api/src/services/contentService.tenantScope.test.mjs
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const mongoose = require("mongoose");
+const common = require("@contexthub/common");
+const contentService = require("./contentService");
+const galleryService = require("./galleryService");
+
+function queryResult(value) {
+  const query = {
+    sort: vi.fn(),
+    skip: vi.fn(),
+    limit: vi.fn(),
+    populate: vi.fn(),
+    lean: vi.fn().mockResolvedValue(value),
+  };
+
+  query.sort.mockReturnValue(query);
+  query.skip.mockReturnValue(query);
+  query.limit.mockReturnValue(query);
+  query.populate.mockReturnValue(query);
+  return query;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("content populate tenant boundaries", () => {
+  it("scopes featured media when reading content by id or slug", async () => {
+    const tenantId = "64b000000000000000000001";
+    const contentId = new mongoose.Types.ObjectId();
+    const byIdQuery = queryResult({ _id: contentId });
+    const bySlugQuery = queryResult({ _id: contentId });
+
+    vi.spyOn(common.Content, "findOne")
+      .mockReturnValueOnce(byIdQuery)
+      .mockReturnValueOnce(bySlugQuery);
+    vi.spyOn(galleryService, "listByContent").mockResolvedValue([]);
+
+    await contentService.getContent({
+      tenantId,
+      contentId: contentId.toString(),
+    });
+    await contentService.getContentBySlug({
+      tenantId,
+      slug: "tenant-safe-content",
+    });
+
+    const expectedPopulate = {
+      path: "featuredMediaId",
+      match: { tenantId },
+    };
+    expect(byIdQuery.populate).toHaveBeenCalledWith(expectedPopulate);
+    expect(bySlugQuery.populate).toHaveBeenCalledWith(expectedPopulate);
+  });
+
+  it("scopes every tenant-owned reference populated in content lists", async () => {
+    const tenantId = "64b000000000000000000001";
+    const listQuery = queryResult([]);
+
+    vi.spyOn(common.Content, "find").mockReturnValue(listQuery);
+    vi.spyOn(common.Content, "countDocuments").mockResolvedValue(0);
+
+    await contentService.listContents({ tenantId });
+
+    expect(listQuery.populate).toHaveBeenCalledWith({
+      path: "categories",
+      match: { tenantId },
+      select: "name slug",
+    });
+    expect(listQuery.populate).toHaveBeenCalledWith({
+      path: "tags",
+      match: { tenantId },
+      select: "slug title",
+    });
+    expect(listQuery.populate).toHaveBeenCalledWith({
+      path: "featuredMediaId",
+      match: { tenantId },
+      select: "url title altText variants",
+    });
+  });
+
+  it("scopes featured media in the scheduled-content date fallback", async () => {
+    const tenantId = "64b000000000000000000001";
+    const contentId = new mongoose.Types.ObjectId();
+    const publishedQuery = queryResult(null);
+    const scheduledQuery = queryResult({ _id: contentId });
+
+    vi.spyOn(common.Content, "findOne")
+      .mockReturnValueOnce(publishedQuery)
+      .mockReturnValueOnce(scheduledQuery);
+    vi.spyOn(galleryService, "listByContent").mockResolvedValue([]);
+
+    await contentService.getContentBySlug({
+      tenantId,
+      slug: "scheduled-content",
+      publishedFrom: "2026-08-01T00:00:00.000Z",
+    });
+
+    const expectedPopulate = {
+      path: "featuredMediaId",
+      match: { tenantId },
+    };
+    expect(publishedQuery.populate).toHaveBeenCalledWith(expectedPopulate);
+    expect(scheduledQuery.populate).toHaveBeenCalledWith(expectedPopulate);
+  });
+});

--- a/apps/api/src/services/mockAuthRemoval.security.test.mjs
+++ b/apps/api/src/services/mockAuthRemoval.security.test.mjs
@@ -1,0 +1,28 @@
+import { access, readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const apiSource = new URL("../", import.meta.url);
+const forbiddenMockModules = [
+  new URL("middleware/mockAuth.js", apiSource),
+  new URL("services/mockAuthService.js", apiSource),
+];
+
+describe("production authentication surface", () => {
+  it("does not ship the legacy mock authentication modules", async () => {
+    for (const moduleUrl of forbiddenMockModules) {
+      await expect(access(moduleUrl, constants.F_OK)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    }
+  });
+
+  it("does not register mock authentication from server or auth routes", async () => {
+    const sources = await Promise.all([
+      readFile(new URL("server.js", apiSource), "utf8"),
+      readFile(new URL("routes/auth.js", apiSource), "utf8"),
+    ]);
+
+    expect(sources.join("\n")).not.toMatch(/mockAuth/i);
+  });
+});


### PR DESCRIPTION
## What changed

- tenant-scopes populated featured media for content reads by ID and slug
- tenant-scopes categories, tags, and featured media in content lists
- covers the scheduled-content date fallback as well as normal reads
- adds regression tests for every affected populate path
- locks the production auth surface against reintroducing the removed `mockAuthService.js` and `mockAuth.js` modules
- replaces the legacy backdoor-like credentials and admin role in server test fixtures with explicit non-production fixture values

## Why

A tenant-scoped content query could populate a referenced Media, Category, or Tag document without reapplying the tenant boundary. A corrupted or attacker-controlled reference could therefore expose metadata from another tenant.

The legacy mock auth implementation is already absent from current production source. The new security test makes that removal an enforced invariant so a hardcoded login module cannot silently return.

## User impact

Normal content responses are unchanged for valid same-tenant references. Invalid or cross-tenant populated references now resolve to `null` or are omitted instead of exposing another tenant's record.

## Validation

- API suite: 39 files, 178 tests passed
- focused security suite: 3 files, 11 tests passed
- API ESLint passed
- new security test files pass Prettier check
- `git diff --check` passed

The repository-wide Prettier check still reports existing formatting drift across the API package; this PR does not reformat unrelated files.