### PR TITLE
Link login footer to developer docs

### DIFF
--- a/apps/admin/src/components/Footer.jsx
+++ b/apps/admin/src/components/Footer.jsx
@@ -1,6 +1,6 @@
-import { GlobeAltIcon } from '@heroicons/react/24/outline'
+import { BookOpenIcon, GlobeAltIcon } from '@heroicons/react/24/outline'
 
-export default function Footer() {
+export default function Footer({ showDeveloperDocs = false }) {
   const currentYear = new Date().getFullYear()
   
   // Basit dil değiştirme (şu an sadece Türkçe)
@@ -9,7 +9,7 @@ export default function Footer() {
   return (
     <footer className="bg-white border-t border-gray-200">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center py-4">
+        <div className="grid grid-cols-1 items-center gap-3 py-4 sm:grid-cols-3">
           {/* Language Selector - Left */}
           <div className="flex items-center">
             <div className="flex items-center gap-2 text-sm text-gray-600">
@@ -18,8 +18,20 @@ export default function Footer() {
             </div>
           </div>
 
+          <div className="flex justify-center">
+            {showDeveloperDocs && (
+              <a
+                href="/docs/overview"
+                className="inline-flex items-center gap-2 rounded-md px-2 py-1 text-sm font-medium text-blue-600 transition-colors hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              >
+                <BookOpenIcon className="h-4 w-4" aria-hidden="true" />
+                <span>Geliştirici dokümantasyonu</span>
+              </a>
+            )}
+          </div>
+
           {/* Brand - Right */}
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 sm:justify-self-end">
             <div className="w-6 h-6 bg-blue-600 rounded flex items-center justify-center">
               <span className="text-white text-xs font-bold">C</span>
             </div>

--- a/apps/admin/src/components/Footer.test.jsx
+++ b/apps/admin/src/components/Footer.test.jsx
@@ -1,0 +1,40 @@
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import Footer from './Footer.jsx'
+
+describe('Footer', () => {
+  let container
+  let root
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    container.remove()
+    delete globalThis.IS_REACT_ACT_ENVIRONMENT
+  })
+
+  it('keeps developer documentation opt-in', async () => {
+    await act(async () => {
+      root.render(<Footer />)
+    })
+
+    expect(container.querySelector('a[href="/docs/overview"]')).toBeNull()
+  })
+
+  it('links login users to the documentation overview', async () => {
+    await act(async () => {
+      root.render(<Footer showDeveloperDocs />)
+    })
+
+    const link = container.querySelector('a[href="/docs/overview"]')
+    expect(link?.textContent).toContain('Geliştirici dokümantasyonu')
+    expect(link?.querySelector('svg')).not.toBeNull()
+  })
+})

--- a/apps/admin/src/pages/auth/Login.jsx
+++ b/apps/admin/src/pages/auth/Login.jsx
@@ -327,7 +327,7 @@ export default function Login() {
           </form>
         </div>
       </div>
-      <Footer />
+      <Footer showDeveloperDocs />
     </div>
   )
 }


### PR DESCRIPTION
## What changed

- adds an opt-in developer documentation link to the shared admin footer
- enables the link only on the login page
- routes directly to `/docs/overview`
- keeps the footer responsive and adds a visible keyboard focus state
- adds component coverage for the opt-in behavior and target URL

## Why

Developers arriving at the ContextHub login page need a direct path to the public SaaS documentation without signing in. Keeping the link opt-in prevents unrelated admin and account flows from changing unexpectedly.

## Validation

- `pnpm --filter @contexthub/admin test` — 32/32 passed
- `pnpm --filter @contexthub/admin build` — passed
- 31 English documentation pages prerendered successfully
- `git diff --check` — passed
