### PR TITLE
Add readiness probe and cluster-wide API rate limiting

### DIFF
--- a/apps/api/src/middleware/originProtection.js
+++ b/apps/api/src/middleware/originProtection.js
@@ -2,6 +2,12 @@ const crypto = require("crypto");
 
 const ORIGIN_SECRET_HEADER = "x-ctx-origin-secret";
 const MIN_ORIGIN_SECRET_BYTES = 32;
+const PUBLIC_PROBE_PATHS = new Set(["/health", "/ready"]);
+
+function isPublicProbePath(url) {
+  const pathname = String(url || "").split("?", 1)[0];
+  return PUBLIC_PROBE_PATHS.has(pathname);
+}
 
 function envFlag(value, defaultValue = false) {
   if (value === undefined || value === null || value === "") {
@@ -61,9 +67,18 @@ function createOriginProtectionHook(env = process.env) {
       return;
     }
 
+    const pathname = String(request.url || "").split("?", 1)[0];
+
+    // Load balancers and process supervisors must be able to probe the origin
+    // without receiving the Edge Gateway credential. These routes expose only
+    // process/dependency state and never application data.
+    if (isPublicProbePath(request.url)) {
+      delete request.headers[ORIGIN_SECRET_HEADER];
+      return;
+    }
+
     const provided = request.headers[ORIGIN_SECRET_HEADER];
     if (!timingSafeSecretEqual(provided, config.secret)) {
-      const pathname = String(request.url || "").split("?", 1)[0];
       request.log.warn(
         { pathname, ip: request.ip },
         "Blocked request without a valid origin credential",
@@ -82,7 +97,9 @@ function createOriginProtectionHook(env = process.env) {
 module.exports = {
   MIN_ORIGIN_SECRET_BYTES,
   ORIGIN_SECRET_HEADER,
+  PUBLIC_PROBE_PATHS,
   createOriginProtectionHook,
+  isPublicProbePath,
   resolveOriginProtectionConfig,
   timingSafeSecretEqual,
 };

--- a/apps/api/src/middleware/originProtection.test.mjs
+++ b/apps/api/src/middleware/originProtection.test.mjs
@@ -5,6 +5,7 @@ const require = createRequire(import.meta.url);
 const fastify = require("fastify");
 const {
   createOriginProtectionHook,
+  isPublicProbePath,
   resolveOriginProtectionConfig,
   timingSafeSecretEqual,
 } = require("./originProtection");
@@ -20,6 +21,8 @@ async function buildApp(env) {
     status: "ok",
     secretVisibleToRoute: Boolean(request.headers["x-ctx-origin-secret"]),
   }));
+  app.get("/ready", async () => ({ status: "ready" }));
+  app.get("/api/private", async () => ({ status: "ok" }));
   return app;
 }
 
@@ -68,17 +71,25 @@ describe("originProtection", () => {
     expect(timingSafeSecretEqual(undefined, TEST_SECRET)).toBe(false);
   });
 
-  it("blocks health requests without a secret", async () => {
+  it("matches probe paths exactly while allowing query strings", () => {
+    expect(isPublicProbePath("/ready?source=lb")).toBe(true);
+    expect(isPublicProbePath("/health/details")).toBe(false);
+  });
+
+  it("allows liveness and readiness probes without a secret", async () => {
     const app = await buildApp({
       NODE_ENV: "production",
       ORIGIN_PROTECTION_ENABLED: "true",
       ORIGIN_SHARED_SECRET: TEST_SECRET,
     });
 
-    const response = await app.inject({ method: "GET", url: "/health" });
-    expect(response.statusCode).toBe(403);
-    expect(response.headers["cache-control"]).toBe("private, no-store");
-    expect(response.json()).toMatchObject({ error: "OriginAccessDenied" });
+    const health = await app.inject({ method: "GET", url: "/health" });
+    const ready = await app.inject({ method: "GET", url: "/ready?probe=1" });
+
+    expect(health.statusCode).toBe(200);
+    expect(health.json()).toMatchObject({ status: "ok" });
+    expect(ready.statusCode).toBe(200);
+    expect(ready.json()).toEqual({ status: "ready" });
   });
 
   it("blocks an incorrect secret", async () => {
@@ -90,7 +101,7 @@ describe("originProtection", () => {
 
     const response = await app.inject({
       method: "GET",
-      url: "/health",
+      url: "/api/private",
       headers: { "x-ctx-origin-secret": "incorrect-secret" },
     });
     expect(response.statusCode).toBe(403);
@@ -105,13 +116,10 @@ describe("originProtection", () => {
 
     const response = await app.inject({
       method: "GET",
-      url: "/health",
+      url: "/api/private",
       headers: { "x-ctx-origin-secret": TEST_SECRET },
     });
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({
-      status: "ok",
-      secretVisibleToRoute: false,
-    });
+    expect(response.json()).toEqual({ status: "ok" });
   });
 });

--- a/apps/api/src/middleware/requestLimitGuard.test.mjs
+++ b/apps/api/src/middleware/requestLimitGuard.test.mjs
@@ -53,6 +53,7 @@ describe('requestLimitGuard', () => {
 
     expect(blocked).toBe(false);
     expect(getFlag).not.toHaveBeenCalled();
+    expect(shouldSkipLimitGuard({ url: '/ready' })).toBe(true);
     expect(shouldSkipLimitGuard({ url: '/api/tenants/abc/limits' })).toBe(true);
   });
 

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -12,12 +12,16 @@ const { database } = require('@contexthub/common');
 const roleService = require('./services/roleService');
 const tenantContext = require('@contexthub/common/src/tenantContext');
 const apiLogger = require('./middleware/apiLogger');
-const { createOriginProtectionHook } = require('./middleware/originProtection');
+const {
+  createOriginProtectionHook,
+  isPublicProbePath,
+} = require('./middleware/originProtection');
 const localRedisClient = require('./lib/localRedis');
 const { getSessionCookieName } = require('./services/sessionSecurity');
 const { resolveCorsOptions } = require('./services/tenantOriginPolicy');
 const { bootstrapExtensions } = require('./lib/pluginHost');
 const { extractTrustedClientIp } = require('./services/clientIp');
+const RedisRateLimitStore = require('./services/redisRateLimitStore');
 
 // Load environment variables from a local .env file when present.  Production deployments should use secrets management instead.
 dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
@@ -128,7 +132,12 @@ async function buildServer(options = {}) {
     max: positiveIntegerEnv('API_RATE_LIMIT_MAX', 1000),
     timeWindow: positiveIntegerEnv('API_RATE_LIMIT_WINDOW_MS', 60 * 1000),
     keyGenerator: extractTrustedClientIp,
-    allowList: (request) => request.raw.url === '/health' || request.raw.url === '/ready',
+    store: options.rateLimitStore || RedisRateLimitStore,
+    // Redis is shared by every PM2 worker, so counters are cluster-global. Keep
+    // the API available during a Redis incident; localRedis reports the outage
+    // and the store emits a throttled warning while requests fail open.
+    skipOnError: true,
+    allowList: (request) => isPublicProbePath(request.raw.url),
     errorResponseBuilder: (_request, context) => ({
       statusCode: 429,
       error: 'RateLimitExceeded',
@@ -251,7 +260,7 @@ async function buildServer(options = {}) {
     const host = (request.headers.host || '').split(':')[0].toLowerCase();
 
     // Allow health checks and internal routes
-    if (request.url === '/health' || request.url === '/ready') {
+    if (isPublicProbePath(request.url)) {
       return done();
     }
 
@@ -332,6 +341,25 @@ async function buildServer(options = {}) {
   // Health check
   app.get('/health', async () => {
     return { status: 'ok', timestamp: Date.now() };
+  });
+
+  // Readiness is deliberately based on the essential datastore only. Redis-backed
+  // abuse/quota controls have an explicit fail-open availability policy, so a Redis
+  // incident must not drain every API worker from the load balancer.
+  const readinessCheck = options.readinessCheck || database.isReady;
+  app.get('/ready', async (_request, reply) => {
+    try {
+      if (await readinessCheck()) {
+        return { status: 'ready', timestamp: Date.now() };
+      }
+    } catch (error) {
+      app.log.error({ err: error }, 'Readiness check failed');
+    }
+
+    return reply.code(503).send({
+      status: 'not_ready',
+      timestamp: Date.now(),
+    });
   });
 
   return app;

--- a/apps/api/src/server.test.mjs
+++ b/apps/api/src/server.test.mjs
@@ -19,9 +19,31 @@ const originalR2Env = new Map(
   Object.keys(TEST_R2_ENV).map((key) => [key, process.env[key]])
 );
 
+class TestRateLimitStore {
+  constructor(options = {}) {
+    this.timeWindow = options.timeWindow;
+    this.counters = new Map();
+  }
+
+  incr(key, callback, max, ban) {
+    const current = (this.counters.get(key) || 0) + 1;
+    this.counters.set(key, current);
+    callback(null, {
+      current,
+      ttl: this.timeWindow,
+      ban: ban !== -1 && current - max > ban,
+    });
+  }
+
+  child(options) {
+    return new TestRateLimitStore(options);
+  }
+}
+
 describe('API server', () => {
   let app;
   let originalLogin;
+  let databaseReady = true;
 
   beforeAll(async () => {
     Object.assign(process.env, TEST_R2_ENV);
@@ -61,6 +83,8 @@ describe('API server', () => {
       throw new Error('Invalid credentials');
     };
     app = await buildServer({
+      readinessCheck: () => databaseReady,
+      rateLimitStore: TestRateLimitStore,
       pluginEntries: [
         path.resolve(
           process.cwd(),
@@ -86,6 +110,19 @@ describe('API server', () => {
     expect(body.status).toBe('ok');
     expect(res.headers['x-content-type-options']).toBe('nosniff');
     expect(res.headers['x-frame-options']).toBe('DENY');
+  });
+
+  it('reports database readiness and returns 503 when it is unavailable', async () => {
+    databaseReady = true;
+    const ready = await app.inject({ method: 'GET', url: '/ready' });
+    expect(ready.statusCode).toBe(200);
+    expect(ready.json().status).toBe('ready');
+
+    databaseReady = false;
+    const unavailable = await app.inject({ method: 'GET', url: '/ready' });
+    expect(unavailable.statusCode).toBe(503);
+    expect(unavailable.json().status).toBe('not_ready');
+    databaseReady = true;
   });
 
   it('serves Swagger from the Edge Gateway bypass path', async () => {

--- a/apps/api/src/services/redisRateLimitStore.js
+++ b/apps/api/src/services/redisRateLimitStore.js
@@ -1,0 +1,99 @@
+const localRedisClient = require('../lib/localRedis');
+
+const RATE_LIMIT_SCRIPT = `
+  local key = KEYS[1]
+  local timeWindow = tonumber(ARGV[1])
+  local max = tonumber(ARGV[2])
+  local ban = tonumber(ARGV[3])
+  local continueExceeding = ARGV[4] == 'true'
+
+  local current = redis.call('INCR', key)
+  local ttl = redis.call('PTTL', key)
+
+  if ttl == -1 or (continueExceeding and current > max) then
+    redis.call('PEXPIRE', key, timeWindow)
+    ttl = timeWindow
+  end
+
+  return {current, ttl, ban ~= -1 and current - max > ban}
+`;
+
+const WARNING_INTERVAL_MS = 60 * 1000;
+let lastWarningAt = 0;
+
+function warnUnavailable(error) {
+  const now = Date.now();
+  if (now - lastWarningAt < WARNING_INTERVAL_MS) {
+    return;
+  }
+
+  lastWarningAt = now;
+  // Do not log the limiter key: it may contain a client IP address.
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[RateLimit] Shared Redis store unavailable; limiter is temporarily fail-open: ${error.message}`
+  );
+}
+
+function routeNamespace(routeOptions) {
+  const method = routeOptions.routeInfo?.method || 'route';
+  const url = routeOptions.routeInfo?.url || 'unknown';
+  return `rate-limit:route:${encodeURIComponent(String(method))}:${encodeURIComponent(String(url))}:`;
+}
+
+class RedisRateLimitStore {
+  constructor(options = {}, redisProvider = localRedisClient, namespace = 'rate-limit:global:') {
+    this.timeWindow = options.timeWindow;
+    this.continueExceeding = Boolean(options.continueExceeding);
+    this.redisProvider = redisProvider;
+    this.namespace = namespace;
+  }
+
+  async incr(key, callback, max, ban) {
+    if (!this.redisProvider.isEnabled()) {
+      const error = new Error('Redis is not connected');
+      warnUnavailable(error);
+      callback(error, null);
+      return;
+    }
+
+    let result;
+    try {
+      const client = this.redisProvider.getClient();
+      result = await client.eval(RATE_LIMIT_SCRIPT, {
+        keys: [`${this.namespace}${key}`],
+        arguments: [
+          String(this.timeWindow),
+          String(max),
+          String(ban),
+          String(this.continueExceeding),
+        ],
+      });
+
+      if (!Array.isArray(result) || result.length < 3) {
+        throw new Error('Redis returned an invalid rate-limit result');
+      }
+    } catch (error) {
+      warnUnavailable(error);
+      callback(error, null);
+      return;
+    }
+
+    callback(null, {
+      current: Number(result[0]),
+      ttl: Number(result[1]),
+      ban: Boolean(Number(result[2])),
+    });
+  }
+
+  child(routeOptions) {
+    return new RedisRateLimitStore(
+      routeOptions,
+      this.redisProvider,
+      routeNamespace(routeOptions)
+    );
+  }
+}
+
+module.exports = RedisRateLimitStore;
+module.exports.RATE_LIMIT_SCRIPT = RATE_LIMIT_SCRIPT;

--- a/apps/api/src/services/redisRateLimitStore.test.mjs
+++ b/apps/api/src/services/redisRateLimitStore.test.mjs
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const RedisRateLimitStore = require('./redisRateLimitStore');
+
+function increment(store, key, max = 10, ban = -1) {
+  return new Promise((resolve, reject) => {
+    store.incr(key, (error, result) => {
+      if (error) reject(error);
+      else resolve(result);
+    }, max, ban);
+  });
+}
+
+describe('RedisRateLimitStore', () => {
+  it('increments an atomic, expiring counter through node-redis', async () => {
+    const evalCommand = vi.fn().mockResolvedValue([2, 59000, 0]);
+    const provider = {
+      isEnabled: () => true,
+      getClient: () => ({ eval: evalCommand }),
+    };
+    const store = new RedisRateLimitStore({
+      timeWindow: 60000,
+      continueExceeding: false,
+    }, provider);
+
+    await expect(increment(store, '203.0.113.8', 10)).resolves.toEqual({
+      current: 2,
+      ttl: 59000,
+      ban: false,
+    });
+    expect(evalCommand).toHaveBeenCalledOnce();
+    expect(evalCommand.mock.calls[0][1]).toEqual({
+      keys: ['rate-limit:global:203.0.113.8'],
+      arguments: ['60000', '10', '-1', 'false'],
+    });
+  });
+
+  it('creates an isolated route namespace while sharing the Redis provider', async () => {
+    const evalCommand = vi.fn().mockResolvedValue([1, 30000, 0]);
+    const provider = {
+      isEnabled: () => true,
+      getClient: () => ({ eval: evalCommand }),
+    };
+    const store = new RedisRateLimitStore({ timeWindow: 60000 }, provider);
+    const child = store.child({
+      timeWindow: 30000,
+      continueExceeding: true,
+      routeInfo: { method: 'POST', url: '/api/auth/login' },
+    });
+
+    await increment(child, '198.51.100.2', 5);
+
+    expect(evalCommand.mock.calls[0][1]).toEqual({
+      keys: ['rate-limit:route:POST:%2Fapi%2Fauth%2Flogin:198.51.100.2'],
+      arguments: ['30000', '5', '-1', 'true'],
+    });
+  });
+
+  it('returns an error when shared Redis is unavailable', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = {
+      isEnabled: () => false,
+      getClient: vi.fn(),
+    };
+    const store = new RedisRateLimitStore({ timeWindow: 60000 }, provider);
+
+    await expect(increment(store, '192.0.2.1')).rejects.toThrow('Redis is not connected');
+    expect(provider.getClient).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+});

--- a/packages/common/src/database.js
+++ b/packages/common/src/database.js
@@ -95,8 +95,11 @@ const disconnectDB = async () => {
   }
 };
 
+const isReady = () => mongoose.connection.readyState === 1;
+
 module.exports = {
   connectDB,
   disconnectDB,
-  createIndexes
+  createIndexes,
+  isReady,
 };


### PR DESCRIPTION
## Summary
- add a Mongo-backed /ready probe while keeping /health as liveness
- allow only /health and /ready through origin protection for infrastructure probes
- move Fastify rate-limit counters from per-process memory to the existing shared Redis service
- keep Redis failures explicitly fail-open with throttled operational warnings

## Validation
- pnpm --filter @contexthub/api test (40 files, 183 tests)
- pnpm --filter @contexthub/api lint
- pnpm --filter @contexthub/common test (3 files, 8 tests)