### PR TITLE
fix(deploy): keep admin backups outside document root

### DIFF
--- a/scripts/deploy-admin.mjs
+++ b/scripts/deploy-admin.mjs
@@ -24,7 +24,7 @@ const config = {
   host: process.env.adminDeployServer,
   username: process.env.adminUser,
   password: process.env.adminPassword,
-  remotePath: process.env.adminDeployPath,
+  remotePath: process.env.adminDeployPath?.replace(/\/+$/, ''),
   localPath: join(rootDir, 'apps/admin/dist')
 };
 


### PR DESCRIPTION
## Özet

Admin deploy hedef yolunun sonundaki `/` kaldırılarak backup dizininin production document root içine oluşturulması engellendi.

## Kök neden

`adminDeployPath=/home/ctxhub/htdocs/ctxhub.net/` biçimindeki sondaki slash, backup adını `/home/ctxhub/htdocs/ctxhub.net/.backup-...` yapıyordu. Her yeni backup önceki iç backup'ları da kopyaladığı için dosya ağacı her deploy'da yaklaşık ikiye katlanıyordu.

## Etki

Yeni backup'lar `/home/ctxhub/htdocs/ctxhub.net.backup-...` biçiminde document root'un kardeşi olur. Production tarafından servis edilmez ve mevcut 30 günlük retention kuralıyla eşleşir.

## Doğrulama

- Deploy yolu normalize edildiğinde mevcut backup/cleanup hesapları doğru kardeş yolu üretiyor.
- Script syntax ve `git diff --check` başarılı.
- Yanlış yerdeki üç backup silinmeden doğru kardeş dizinlere taşındı.